### PR TITLE
RedundantEmptyFinallyBlock

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockAnalyzer.cs
@@ -47,7 +47,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (node == null)
                 return false;
 
-            if (IsFinallyBlockEmpty(node))
+            if (!IsFinallyBlockEmpty(node))
                 return false;
 
             diagnostic = Diagnostic.Create(descriptor, node.GetLocation());
@@ -56,7 +56,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
         static bool IsFinallyBlockEmpty(FinallyClauseSyntax finallyClause)
         {
-            return finallyClause.ChildNodes().OfType<BlockSyntax>().First().DescendantNodes().Any();
+            return finallyClause.Block.Statements.Count == 0;
         }
 
         //		class GatherVisitor : GatherVisitorBase<RedundantEmptyFinallyBlockAnalyzer>

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockAnalyzer.cs
@@ -47,59 +47,16 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (node == null)
                 return false;
 
-            if (!IsFinallyBlockEmpty(node))
+            if (IsFinallyBlockNotEmpty(node))
                 return false;
 
             diagnostic = Diagnostic.Create(descriptor, node.GetLocation());
             return true;
         }
 
-        static bool IsFinallyBlockEmpty(FinallyClauseSyntax finallyClause)
+        static bool IsFinallyBlockNotEmpty(FinallyClauseSyntax finallyClause)
         {
-            return finallyClause.Block.Statements.Count == 0;
+            return finallyClause.Block.Statements.Any();
         }
-
-        //		class GatherVisitor : GatherVisitorBase<RedundantEmptyFinallyBlockAnalyzer>
-        //		{
-        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-        //				: base (semanticModel, addDiagnostic, cancellationToken)
-        //			{
-        //			}
-
-        ////			static bool IsEmpty (BlockStatement blockStatement)
-        ////			{
-        ////				return !blockStatement.Descendants.Any(s => s is Statement && !(s is EmptyStatement || s is BlockStatement));
-        ////			}
-        ////
-        ////			public override void VisitBlockStatement(BlockStatement blockStatement)
-        ////			{
-        ////				base.VisitBlockStatement(blockStatement);
-        ////				if (blockStatement.Role != TryCatchStatement.FinallyBlockRole || !IsEmpty (blockStatement))
-        ////					return;
-        ////				var tryCatch = blockStatement.Parent as TryCatchStatement;
-        ////				if (tryCatch == null)
-        ////					return;
-        ////				AddDiagnosticAnalyzer(new CodeIssue(
-        ////					tryCatch.FinallyToken.StartLocation,
-        ////					blockStatement.EndLocation,
-        ////					ctx.TranslateString(""),
-        ////					ctx.TranslateString(""),
-        ////					s => {
-        ////						if (tryCatch.CatchClauses.Any()) {
-        ////							s.Remove(tryCatch.FinallyToken);
-        ////							s.Remove(blockStatement); 
-        ////							s.FormatText(tryCatch);
-        ////							return;
-        ////						}
-        ////						s.Remove(tryCatch.TryToken);
-        ////						s.Remove(tryCatch.TryBlock.LBraceToken);
-        ////						s.Remove(tryCatch.TryBlock.RBraceToken);
-        ////						s.Remove(tryCatch.FinallyToken);
-        ////						s.Remove(tryCatch.FinallyBlock); 
-        ////						s.FormatText(tryCatch.Parent);
-        ////					}
-        ////				) { IssueMarker = IssueMarker.GrayOut });
-        ////			}
-        //		}
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantEmptyFinallyBlockCodeFixProvider.cs
@@ -1,12 +1,12 @@
 using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeFixes;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
-
     [ExportCodeFixProvider(LanguageNames.CSharp), System.Composition.Shared]
     public class RedundantEmptyFinallyBlockCodeFixProvider : CodeFixProvider
     {
@@ -34,8 +34,41 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var node = root.FindNode(context.Span);
             //if (!node.IsKind(SyntaxKind.BaseList))
             //	continue;
+            var tryStatement = (node as FinallyClauseSyntax).Parent as TryStatementSyntax;
+            if (tryStatement != null && !tryStatement.Catches.Any())
+            {
+                FixEmptyFinallyWithoutCatchClause(node as FinallyClauseSyntax, tryStatement, diagnostic, context, root);
+            }
+            else if (tryStatement != null && tryStatement.Catches.Any())
+            {
+                FixEmptyFinallyWithCatchClause(node as FinallyClauseSyntax, diagnostic, context, root);
+            }
             var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
             context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove 'finally'", document.WithSyntaxRoot(newRoot)), diagnostic);
+        }
+
+        public void FixEmptyFinallyWithoutCatchClause(FinallyClauseSyntax finallyClause, TryStatementSyntax tryStatement, Diagnostic diagnostic,
+            CodeFixContext context, SyntaxNode root)
+        {
+            context.RegisterCodeFix(CodeActionFactory.Create(finallyClause.Span, diagnostic.Severity,
+            "Remove redundant 'finally' ", token =>
+            {
+                var blockSyntax = tryStatement.Block;
+                var newRoot = root.ReplaceNode(tryStatement, blockSyntax.WithoutLeadingTrivia());
+
+                return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+            }), diagnostic);
+        }
+
+        public void FixEmptyFinallyWithCatchClause(FinallyClauseSyntax finallyClause, Diagnostic diagnostic,
+            CodeFixContext context, SyntaxNode root)
+        {
+            context.RegisterCodeFix(CodeActionFactory.Create(finallyClause.Span, diagnostic.Severity,
+            "Remove redundant 'finally' ", token =>
+            {
+                var newRoot = root.RemoveNode(finallyClause, SyntaxRemoveOptions.KeepNoTrivia);
+                return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+            }), diagnostic);
         }
     }
 }

--- a/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
@@ -4,13 +4,12 @@ using RefactoringEssentials.CSharp.Diagnostics;
 namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 {
     [TestFixture]
-    [Ignore("TODO: Issue not ported yet")]
     public class RedundantEmptyFinallyBlockTests : CSharpDiagnosticTestBase
     {
         [Test]
         public void TestRedundantTry()
         {
-            Test<RedundantEmptyFinallyBlockAnalyzer>(@"
+            Analyze<RedundantEmptyFinallyBlockAnalyzer>(@"
 using System;
 class Test
 {
@@ -39,7 +38,7 @@ class Test
         [Test]
         public void TestSimpleCase()
         {
-            Test<RedundantEmptyFinallyBlockAnalyzer>(@"
+            Analyze<RedundantEmptyFinallyBlockAnalyzer>(@"
 using System;
 class Test
 {

--- a/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using RefactoringEssentials.CSharp.Diagnostics;
 
@@ -59,11 +60,10 @@ class Test
 	static void Main (string[] args)
 	{
 		try {
-			Console.WriteLine (""1"");
-			Console.WriteLine (""2"");
+			Console.WriteLine(""1"");
+			Console.WriteLine(""2"");
 		} catch (Exception) {
-		}  
-	}
+		} 	}
 }
 ");
         }

--- a/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantEmptyFinallyBlockTests.cs
@@ -18,8 +18,8 @@ class Test
 		try {
 			Console.WriteLine (""1"");
 			Console.WriteLine (""2"");
-		} finally {
-		}
+		} $finally {
+		}$
 	}
 }
 ", @"
@@ -48,8 +48,8 @@ class Test
 			Console.WriteLine (""1"");
 			Console.WriteLine (""2"");
 		} catch (Exception) {
-		} finally {
-		}
+		} $finally {
+		}$
 	}
 }
 ", @"
@@ -101,6 +101,8 @@ class Test
 			Console.WriteLine(""2"");
 		}
 		// ReSharper disable once RedundantEmptyFinallyBlock
++#pragma warning disable " + CSharpDiagnosticIDs.RedundantEmptyFinallyBlockAnalyzerID + @"
+
  		finally {
 		}
 	}


### PR DESCRIPTION
Would you rather check an empty finally block this way or would it be preferable to count the number of descendants and count (the number of leading trivia + syntax tokens) and if the difference between number of descendants and the big count is over 0, than the finally block is not empty ?