### PR TITLE
Porting RedundantExplicitSizeArray

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeAnalyzer.cs
@@ -46,7 +46,12 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var node = nodeContext.Node as ArrayCreationExpressionSyntax;
             var arrayType = node?.Type;
 
-            if (arrayType == null || !arrayType.RankSpecifiers.Any())
+            if (arrayType == null)
+                return false;
+
+
+            var rs = arrayType.RankSpecifiers;
+            if (rs.Count != 1 || rs[0].Sizes.Count != 1)
                 return false;
 
             var intSizeValue = nodeContext.SemanticModel.GetConstantValue(arrayType.RankSpecifiers[0].Sizes[0]);

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeAnalyzer.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
@@ -34,7 +33,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                         nodeContext.ReportDiagnostic(diagnostic);
                     }
                 },
-                 SyntaxKind.ArrayCreationExpression 
+                 SyntaxKind.ArrayCreationExpression
             );
         }
 
@@ -48,7 +47,6 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
             if (arrayType == null)
                 return false;
-
 
             var rs = arrayType.RankSpecifiers;
             if (rs.Count != 1 || rs[0].Sizes.Count != 1)
@@ -66,34 +64,5 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
             return false;
         }
-
-        //		class GatherVisitor : GatherVisitorBase<RedundantExplicitArraySizeAnalyzer>
-        //		{
-        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-        //				: base (semanticModel, addDiagnostic, cancellationToken)
-        //			{
-        //			}
-
-        ////			public override void VisitArrayCreateExpression(ArrayCreateExpression arrayCreateExpression)
-        ////			{
-        ////				base.VisitArrayCreateExpression(arrayCreateExpression);
-        ////				if (arrayCreateExpression.Arguments.Count != 1)
-        ////					return;
-        ////				var arg = arrayCreateExpression.Arguments.Single() as PrimitiveExpression;
-        ////				if (arg == null || !(arg.Value is int))
-        ////					return;
-        ////				var value = (int)arg.Value;
-        ////				if (value == 0)
-        ////					return;
-        ////				if (arrayCreateExpression.Initializer.Elements.Count() == value) {
-        ////					AddDiagnosticAnalyzer(new CodeIssue(
-        ////						arg,
-        ////						ctx.TranslateString(""),
-        ////						string.Format(ctx.TranslateString(""), arg),
-        ////						s => { s.Remove(arg); }
-        ////					) { IssueMarker = IssueMarker.GrayOut });
-        ////				}
-        ////			}
-        //		}
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
@@ -1,13 +1,13 @@
 using Microsoft.CodeAnalysis;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeFixes;
-using System.Threading.Tasks;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
-
     [ExportCodeFixProvider(LanguageNames.CSharp), System.Composition.Shared]
     public class RedundantExplicitArraySizeCodeFixProvider : CodeFixProvider
     {
@@ -33,15 +33,14 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
             var node = root.FindNode(context.Span);
-            var arrayType = ((ArrayCreationExpressionSyntax) node)?.Type;
-            if (arrayType != null)
-            {
-                var rs = arrayType.RankSpecifiers;
-                var newRoot = root.RemoveNode(rs[0], SyntaxRemoveOptions.KeepNoTrivia);
-                context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
-            }
-            //var arrayType = ((ArrayCreationExpressionSyntax) node).Type;
-            //a RemoveNode of arrayType.RankSpecifiers[0] should do it.
+            var array = node as ArrayCreationExpressionSyntax;
+            if (array == null)
+                return;
+
+            var rs = array.Type.RankSpecifiers;
+            Debug.WriteLine(rs[0]);
+            var newRoot = root.RemoveNode(rs[0], SyntaxRemoveOptions.KeepNoTrivia);
+            context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
         }
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
@@ -33,10 +33,15 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
             var node = root.FindNode(context.Span);
-            var arrayType = ((ArrayCreationExpressionSyntax) node).Type;
+            var arrayType = ((ArrayCreationExpressionSyntax) node)?.Type;
+            if (arrayType != null)
+            {
+                var rs = arrayType.RankSpecifiers;
+                var newRoot = root.RemoveNode(rs[0], SyntaxRemoveOptions.KeepNoTrivia);
+                context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
+            }
+            //var arrayType = ((ArrayCreationExpressionSyntax) node).Type;
             //a RemoveNode of arrayType.RankSpecifiers[0] should do it.
-            var newRoot = root.RemoveNode(arrayType.RankSpecifiers[0], SyntaxRemoveOptions.KeepNoTrivia);
-            context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
         }
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeFixes;
 using System.Threading.Tasks;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
@@ -32,10 +33,10 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
             var node = root.FindNode(context.Span);
-            //if (!node.IsKind(SyntaxKind.BaseList))
-            //	continue;
-            var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
-            context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove '{0}'", document.WithSyntaxRoot(newRoot)), diagnostic);
+            var arrayType = ((ArrayCreationExpressionSyntax) node).Type;
+            //a RemoveNode of arrayType.RankSpecifiers[0] should do it.
+            var newRoot = root.RemoveNode(arrayType.RankSpecifiers[0], SyntaxRemoveOptions.KeepNoTrivia);
+            context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
         }
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantExplicitArraySizeCodeFixProvider.cs
@@ -33,13 +33,9 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
             var node = root.FindNode(context.Span);
-            var array = node as ArrayCreationExpressionSyntax;
-            if (array == null)
+            if (node == null)
                 return;
-
-            var rs = array.Type.RankSpecifiers;
-            Debug.WriteLine(rs[0]);
-            var newRoot = root.RemoveNode(rs[0], SyntaxRemoveOptions.KeepNoTrivia);
+            var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
             context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Remove the redundant size indicator", document.WithSyntaxRoot(newRoot)), diagnostic);
         }
     }

--- a/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
@@ -4,13 +4,12 @@ using RefactoringEssentials.CSharp.Diagnostics;
 namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 {
     [TestFixture]
-    [Ignore("TODO: Issue not ported yet")]
     public class RedundantExplicitArraySizeTests : CSharpDiagnosticTestBase
     {
         [Test]
         public void TestSimpleCase()
         {
-            Test<RedundantExplicitArraySizeAnalyzer>(@"
+            Analyze<RedundantExplicitArraySizeAnalyzer>(@"
 class Test
 {
 	void Foo ()

--- a/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
@@ -14,7 +14,7 @@ class Test
 {
 	void Foo ()
 	{
-		var foo = new int[3] { 1, 2, 3 };
+		var foo = new int[$3$] { 1, 2, 3 };
 	}
 }
 ", @"

--- a/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantExplicitArraySizeTests.cs
@@ -79,6 +79,7 @@ class Test
 	void Foo ()
 	{
 		// ReSharper disable once RedundantExplicitArraySize
+#pragma warning disable " + CSharpDiagnosticIDs.RedundantExplicitArraySizeAnalyzerID + @"
 		var foo = new int[3] { 1, 2, 3 };
 	}
 }


### PR DESCRIPTION
I'm look for the way to get the int value inside the brackets. I dont know what it is. I tested it with an array creation expression and thought  either Rank or Sizes.Count could help but they didnt.
As for the code fix provider, I think it'll be simple, recreate a new node without specifying the int value.