### PR TITLE
Support project.json-based projects in addition to packages.config-based projects

### DIFF
--- a/RefactoringEssentials/RefactoringEssentials.nuspec
+++ b/RefactoringEssentials/RefactoringEssentials.nuspec
@@ -20,7 +20,7 @@
 		</frameworkAssemblies>
 	</metadata>
 	<files>
-		<file src="RefactoringEssentials.dll" target="tools\analyzers\" />
+		<file src="RefactoringEssentials.dll" target="analyzers\dotnet\" />
 		<file src="tools\install.ps1" target="tools\" />
 		<file src="tools\uninstall.ps1" target="tools\" />
 	</files>

--- a/RefactoringEssentials/tools/install.ps1
+++ b/RefactoringEssentials/tools/install.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzerPath = join-path $toolsPath "analyzers"
+$analyzerPath = join-path (split-Path -path $toolsPath -parent) "analyzers\dotnet"
 $analyzerFilePath = join-path $analyzerPath "RefactoringEssentials.dll"
 
 $project.Object.AnalyzerReferences.Add("$analyzerFilePath")

--- a/RefactoringEssentials/tools/uninstall.ps1
+++ b/RefactoringEssentials/tools/uninstall.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzerPath = join-path $toolsPath "analyzers"
+$analyzerPath = join-path (split-Path -path $toolsPath -parent) "analyzers\dotnet"
 $analyzerFilePath = join-path $analyzerPath "RefactoringEssentials.dll"
 
 $project.Object.AnalyzerReferences.Remove("$analyzerFilePath")


### PR DESCRIPTION
This PR updates the .nuspec file to support the final suggested package layout, which will support using RefactoringEssentials via `project.json`-based projects (like UWP) in addition to traditional `packages.config`-based projects. This includes people porting older projects (like traditional PCLs) to `project.json`, not just the new `dotnet` (so-called "modern PCL") projects.