### PR TITLE
C# ConvertStatementBodyToExpressionBody is already implemented

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertStatementBodyToExpressionBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertStatementBodyToExpressionBodyCodeRefactoringProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Formatting;
 namespace RefactoringEssentials.CSharp.CodeRefactorings
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Convert statement body member to expression body")]
-    [NotPortedYet]
     public class ConvertStatementBodyToExpressionBodyCodeRefactoringProvider : CodeRefactoringProvider
     {
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)

--- a/RefactoringEssentials/missing.md
+++ b/RefactoringEssentials/missing.md
@@ -7,7 +7,6 @@
 
 * AutoLinqSumAction
 * ChangeAccessModifierAction
-* ConvertStatementBodyToExpressionBodyCodeRefactoringProvider
 * CreateDelegateAction
 * CreateIndexerAction
 * CreateOverloadWithoutParameterAction


### PR DESCRIPTION
It looks like that both refactoring provider and tests are implemented, so it can be removed from missing.md