### PR TITLE
Ported ObjectCreationArgumentList

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListAnalyzer.cs
@@ -1,14 +1,16 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [NotPortedYet]
     public class RedundantObjectCreationArgumentListAnalyzer : DiagnosticAnalyzer
     {
-        static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
+        private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
             CSharpDiagnosticIDs.RedundantObjectCreationArgumentListAnalyzerID,
             GettextCatalog.GetString("When object creation uses object or collection initializer, empty argument list is redundant"),
             GettextCatalog.GetString("Empty argument list is redundant"),
@@ -23,55 +25,38 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
         public override void Initialize(AnalysisContext context)
         {
-            //context.RegisterSyntaxNodeAction(
-            //	(nodeContext) => {
-            //		Diagnostic diagnostic;
-            //		if (TryGetDiagnostic (nodeContext, out diagnostic)) {
-            //			nodeContext.ReportDiagnostic(diagnostic);
-            //		}
-            //	}, 
-            //	new SyntaxKind[] { SyntaxKind.None }
-            //);
+            context.RegisterSyntaxNodeAction(
+                (nodeContext) =>
+                {
+                    Diagnostic diagnostic;
+                    if (TryGetDiagnostic(nodeContext, out diagnostic))
+                    {
+                        nodeContext.ReportDiagnostic(diagnostic);
+                    }
+                },
+                 SyntaxKind.ObjectCreationExpression
+            );
         }
 
-        static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
+        private static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
         {
             diagnostic = default(Diagnostic);
             if (nodeContext.IsFromGeneratedCode())
                 return false;
-            //var node = nodeContext.Node as ;
-            //diagnostic = Diagnostic.Create (descriptor, node.GetLocation ());
-            //return true;
-            return false;
+
+            var objectCreation = nodeContext.Node as ObjectCreationExpressionSyntax;
+            if (objectCreation?.Initializer == null ||
+                objectCreation.ArgumentList != null ||
+                objectCreation.ArgumentList?.Arguments.Count == 0)
+                return false;
+
+            var argumentList = objectCreation.ArgumentList;
+            //Means that a maximum of open and close braces
+            if (argumentList != null && argumentList.ChildTokens().Count() <= 2)
+                return false;
+
+            diagnostic = Diagnostic.Create(descriptor, objectCreation.GetLocation());
+            return true;
         }
-
-        //		class GatherVisitor : GatherVisitorBase<RedundantObjectCreationArgumentListAnalyzer>
-        //		{
-        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-        //				: base (semanticModel, addDiagnostic, cancellationToken)
-        //			{
-        //			}
-
-        ////			public override void VisitObjectCreateExpression(ObjectCreateExpression objectCreateExpression)
-        ////			{
-        ////				base.VisitObjectCreateExpression(objectCreateExpression);
-        ////
-        ////				if (objectCreateExpression.Initializer.IsNull ||
-        ////					objectCreateExpression.Arguments.Count > 0 ||
-        ////					objectCreateExpression.LParToken.IsNull)
-        ////					return;
-        ////
-        ////				AddDiagnosticAnalyzer(new CodeIssue(objectCreateExpression.LParToken.StartLocation, objectCreateExpression.RParToken.EndLocation,
-        ////				         ctx.TranslateString(""),
-        ////				         ctx.TranslateString(""), script => {
-        ////					var l1 = objectCreateExpression.LParToken.GetPrevNode().EndLocation;
-        ////					var l2 = objectCreateExpression.RParToken.GetNextNode().StartLocation;
-        ////					var o1 = script.GetCurrentOffset(l1);
-        ////					var o2 = script.GetCurrentOffset(l2);
-        ////
-        ////					script.Replace(o1, o2 - o1, " ");
-        ////					}) { IssueMarker = IssueMarker.GrayOut });
-        ////			}
-        //		}
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListAnalyzer.cs
@@ -46,16 +46,12 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
             var objectCreation = nodeContext.Node as ObjectCreationExpressionSyntax;
             if (objectCreation?.Initializer == null ||
-                objectCreation.ArgumentList != null ||
-                objectCreation.ArgumentList?.Arguments.Count == 0)
+                objectCreation.ArgumentList == null ||
+                objectCreation.ArgumentList.Arguments.Any()||
+                objectCreation.Initializer.IsMissing)
                 return false;
 
-            var argumentList = objectCreation.ArgumentList;
-            //Means that a maximum of open and close braces
-            if (argumentList != null && argumentList.ChildTokens().Count() <= 2)
-                return false;
-
-            diagnostic = Diagnostic.Create(descriptor, objectCreation.GetLocation());
+            diagnostic = Diagnostic.Create(descriptor, objectCreation.ArgumentList.GetLocation());
             return true;
         }
     }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInCode/RedundantObjectCreationArgumentListCodeFixProvider.cs
@@ -34,16 +34,15 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var diagnostics = context.Diagnostics;
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
-            var node = root.FindNode(context.Span) ;
-            //if (!node.IsKind(SyntaxKind.BaseList))
-            //	continue;
+            var node = root.FindNode(context.Span) as ObjectCreationExpressionSyntax ;
+
             if (node == null)
                 return;
-            
+
+
             var newRoot = root.ReplaceNode(
                 node,
                 node
-                .WithExpressions(SyntaxFactory.SeparatedList(node..ToArray()))
                 .WithLeadingTrivia(node.GetLeadingTrivia())
                 .WithTrailingTrivia(node.GetTrailingTrivia()))
                 .WithAdditionalAnnotations(Formatter.Annotation);

--- a/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
@@ -4,7 +4,6 @@ using RefactoringEssentials.CSharp.Diagnostics;
 namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 {
     [TestFixture]
-    [Ignore("TODO: Issue not ported yet")]
     public class RedundantObjectCreationArgumentListTests : CSharpDiagnosticTestBase
     {
         [Test]

--- a/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
@@ -31,7 +31,7 @@ class TestClass
 		};
 	}
 }";
-            Test<RedundantObjectCreationArgumentListAnalyzer>(input, 1, output);
+            Analyze<RedundantObjectCreationArgumentListAnalyzer>(input, output);
         }
 
         [Test]

--- a/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
+++ b/Tests/CSharp/Diagnostics/RedundantObjectCreationArgumentListTests.cs
@@ -15,7 +15,7 @@ class TestClass
 	public int Prop { get; set; }
 	void TestMethod ()
 	{
-		var x = new TestClass () {
+		var x = new TestClass $()$ {
 			Prop = 1
 		};
 	}
@@ -26,7 +26,7 @@ class TestClass
 	public int Prop { get; set; }
 	void TestMethod ()
 	{
-		var x = new TestClass {
+		var x = new TestClass  {
 			Prop = 1
 		};
 	}
@@ -49,7 +49,7 @@ class TestClass
 		var y = new TestClass (1) { };
 	}
 }";
-            Test<RedundantObjectCreationArgumentListAnalyzer>(input, 0);
+            Analyze<RedundantObjectCreationArgumentListAnalyzer>(input);
         }
 
         [Test]
@@ -62,12 +62,13 @@ class TestClass
 	void TestMethod ()
 	{
 		// ReSharper disable once RedundantEmptyObjectCreationArgumentList
+#pragma warning disable " + CSharpDiagnosticIDs.RedundantObjectCreationArgumentListAnalyzerID + @"
 		var x = new TestClass () {
 			Prop = 1
 		};
 	}
 }";
-            Test<RedundantObjectCreationArgumentListAnalyzer>(input, 0);
+            Analyze<RedundantObjectCreationArgumentListAnalyzer>(input);
         }
 
     }


### PR DESCRIPTION
Missing logic to remove '()'
Tried logic from RemoveCommaInArrayInitialisation but not working, test is failing and the tokens are still there.
I'd like to know the logic for removing syntax token
Tried the solutions from 
https://stackoverflow.com/questions/21435665/remove-extraneous-semicolons-in-c-sharp-using-roslyn-replace-w-empty-trivia

https://stackoverflow.com/questions/11714557/simple-way-to-remove-openparen-syntaxtoken-from-argumentlistsyntax

I have issues, as usual.