### PR TITLE
Port RedundantUseArrayCreationExpression

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
@@ -50,9 +50,9 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (invocationSymbol == null)
                 return false;
             System.Array.CreateInstance(typeof(int), 10);
-            new int[10, 20, i];
+            //new int[10, 20, i];
 
-            if (invocationSymbol.Name != "CreateInstance" || !invocationSymbol.ContainingType.IsArrayType())
+            if (invocationSymbol.Name != "CreateInstance") // || !invocationSymbol.ContainingType)
                 return false;
 
             if (node.ArgumentList == null ||
@@ -74,6 +74,11 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (!argumentChildLiteralExpression.IsKind(SyntaxKind.NumericLiteralExpression))
                 return false;
 
+            var typeOfFirstArgument = nodeContext.SemanticModel.GetTypeInfo(node.ArgumentList.Arguments[1]).ConvertedType;
+            if (typeOfFirstArgument != null && !typeOfFirstArgument.IsValueType)
+            {
+                return false;
+            }
             ////				var argRR = ctx.Resolve(invocationExpression.Arguments.ElementAt(1));
             ////				if (!argRR.Type.IsKnownType(KnownTypeCode.Int32))
             ////					return;

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
@@ -1,14 +1,16 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
+using System.Linq;
+using SyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [NotPortedYet]
     public class UseArrayCreationExpressionAnalyzer : DiagnosticAnalyzer
     {
-        static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
+        private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
             CSharpDiagnosticIDs.UseArrayCreationExpressionAnalyzerID,
             GettextCatalog.GetString("Use array creation expression"),
             GettextCatalog.GetString("Use array create expression"),
@@ -22,26 +24,62 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
         public override void Initialize(AnalysisContext context)
         {
-            //context.RegisterSyntaxNodeAction(
-            //	(nodeContext) => {
-            //		Diagnostic diagnostic;
-            //		if (TryGetDiagnostic (nodeContext, out diagnostic)) {
-            //			nodeContext.ReportDiagnostic(diagnostic);
-            //		}
-            //	}, 
-            //	new SyntaxKind[] { SyntaxKind.None }
-            //);
+            context.RegisterSyntaxNodeAction(
+                (nodeContext) =>
+                {
+                    Diagnostic diagnostic;
+                    if (TryGetDiagnostic(nodeContext, out diagnostic))
+                    {
+                        nodeContext.ReportDiagnostic(diagnostic);
+                    }
+                },
+                 SyntaxKind.InvocationExpression
+            );
         }
 
-        static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
+        private static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
         {
             diagnostic = default(Diagnostic);
             if (nodeContext.IsFromGeneratedCode())
                 return false;
-            //var node = nodeContext.Node as ;
-            //diagnostic = Diagnostic.Create (descriptor, node.GetLocation ());
-            //return true;
-            return false;
+            var node = nodeContext.Node as InvocationExpressionSyntax;
+            if (node == null)
+                return false;
+
+            var invocationSymbol = nodeContext.SemanticModel.GetSymbolInfo(node).Symbol;
+            if (invocationSymbol == null)
+                return false;
+            System.Array.CreateInstance(typeof(int), 10);
+            new int[10, 20, i];
+
+            if (invocationSymbol.Name != "CreateInstance" || !invocationSymbol.ContainingType.IsArrayType())
+                return false;
+
+            if (node.ArgumentList == null ||
+               node.ArgumentList != null && node.ArgumentList.Arguments.Count <= 1)
+                return false;
+
+            if (node.ArgumentList.Arguments.FirstOrDefault().Expression == null)
+                return false;
+
+            var firstArgument = node.ArgumentList.Arguments.FirstOrDefault().Expression as TypeOfExpressionSyntax;
+            if (firstArgument == null)
+                return false;
+
+            var argumentChildLiteralExpression =
+                node.ArgumentList.Arguments[1].ChildNodes().FirstOrDefault() as LiteralExpressionSyntax;
+            if (argumentChildLiteralExpression == null)
+                return false;
+
+            if (!argumentChildLiteralExpression.IsKind(SyntaxKind.NumericLiteralExpression))
+                return false;
+
+            ////				var argRR = ctx.Resolve(invocationExpression.Arguments.ElementAt(1));
+            ////				if (!argRR.Type.IsKnownType(KnownTypeCode.Int32))
+            ////					return;
+
+            diagnostic = Diagnostic.Create(descriptor, node.GetLocation());
+            return true;
         }
 
         //		class GatherVisitor : GatherVisitorBase<UseArrayCreationExpressionAnalyzer>
@@ -50,7 +88,6 @@ namespace RefactoringEssentials.CSharp.Diagnostics
         //				: base (semanticModel, addDiagnostic, cancellationToken)
         //			{
         //			}
-
 
         ////			public override void VisitInvocationExpression(InvocationExpression invocationExpression)
         ////			{
@@ -72,8 +109,8 @@ namespace RefactoringEssentials.CSharp.Diagnostics
         ////
         ////				AddDiagnosticAnalyzer(new CodeIssue(
         ////					invocationExpression,
-        ////					ctx.TranslateString(""), 
-        ////					ctx.TranslateString(""), 
+        ////					ctx.TranslateString(""),
+        ////					ctx.TranslateString(""),
         ////					script => {
         ////						var ac = new ArrayCreateExpression {
         ////							Type = firstArg.Type.Clone()

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionAnalyzer.cs
@@ -49,10 +49,8 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var invocationSymbol = nodeContext.SemanticModel.GetSymbolInfo(node).Symbol;
             if (invocationSymbol == null)
                 return false;
-            System.Array.CreateInstance(typeof(int), 10);
-            //new int[10, 20, i];
 
-            if (invocationSymbol.Name != "CreateInstance") // || !invocationSymbol.ContainingType)
+            if (invocationSymbol.Name != "CreateInstance")
                 return false;
 
             if (node.ArgumentList == null ||
@@ -66,66 +64,25 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (firstArgument == null)
                 return false;
 
-            var argumentChildLiteralExpression =
-                node.ArgumentList.Arguments[1].ChildNodes().FirstOrDefault() as LiteralExpressionSyntax;
+            var argumentChildLiteralExpression = node.ArgumentList.Arguments[1].Expression as LiteralExpressionSyntax;
             if (argumentChildLiteralExpression == null)
                 return false;
 
             if (!argumentChildLiteralExpression.IsKind(SyntaxKind.NumericLiteralExpression))
                 return false;
 
-            var typeOfFirstArgument = nodeContext.SemanticModel.GetTypeInfo(node.ArgumentList.Arguments[1]).ConvertedType;
-            if (typeOfFirstArgument != null && !typeOfFirstArgument.IsValueType)
+            var typeOfFirstArgument = node.ArgumentList.Arguments[0].Expression as TypeOfExpressionSyntax;
+            if (typeOfFirstArgument == null)
             {
                 return false;
             }
-            ////				var argRR = ctx.Resolve(invocationExpression.Arguments.ElementAt(1));
-            ////				if (!argRR.Type.IsKnownType(KnownTypeCode.Int32))
-            ////					return;
+
+            var typeSymbol = nodeContext.SemanticModel.GetSymbolInfo((typeOfFirstArgument).Type).Symbol;
+            if (!typeSymbol.OriginalDefinition.Equals(nodeContext.SemanticModel.Compilation.GetTypeByMetadataName("System.Int32")))
+                return false;
 
             diagnostic = Diagnostic.Create(descriptor, node.GetLocation());
             return true;
         }
-
-        //		class GatherVisitor : GatherVisitorBase<UseArrayCreationExpressionAnalyzer>
-        //		{
-        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-        //				: base (semanticModel, addDiagnostic, cancellationToken)
-        //			{
-        //			}
-
-        ////			public override void VisitInvocationExpression(InvocationExpression invocationExpression)
-        ////			{
-        ////				base.VisitInvocationExpression(invocationExpression);
-        ////
-        ////				var rr = ctx.Resolve(invocationExpression) as CSharpInvocationResolveResult;
-        ////				if (rr == null || rr.IsError)
-        ////					return;
-        ////
-        ////				if (rr.Member.Name != "CreateInstance" ||
-        ////				    !rr.Member.DeclaringType.IsKnownType(KnownTypeCode.Array))
-        ////					return;
-        ////				var firstArg = invocationExpression.Arguments.FirstOrDefault() as TypeOfExpression;
-        ////				if (firstArg == null)
-        ////					return;
-        ////				var argRR = ctx.Resolve(invocationExpression.Arguments.ElementAt(1));
-        ////				if (!argRR.Type.IsKnownType(KnownTypeCode.Int32))
-        ////					return;
-        ////
-        ////				AddDiagnosticAnalyzer(new CodeIssue(
-        ////					invocationExpression,
-        ////					ctx.TranslateString(""),
-        ////					ctx.TranslateString(""),
-        ////					script => {
-        ////						var ac = new ArrayCreateExpression {
-        ////							Type = firstArg.Type.Clone()
-        ////						};
-        ////						foreach (var arg in invocationExpression.Arguments.Skip(1))
-        ////							ac.Arguments.Add(arg.Clone()) ;
-        ////						script.Replace(invocationExpression, ac);
-        ////					}
-        ////				));
-        ////			}
-        //		}
     }
 }

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/UseArrayCreationExpressionCodeFixProvider.cs
@@ -3,6 +3,8 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeFixes;
 using System.Threading.Tasks;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
 {
@@ -31,9 +33,12 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var diagnostics = context.Diagnostics;
             var root = await document.GetSyntaxRootAsync(cancellationToken);
             var diagnostic = diagnostics.First();
-            var node = root.FindNode(context.Span);
-            //if (!node.IsKind(SyntaxKind.BaseList))
-            //	continue;
+            var node = root.FindNode(context.Span) as InvocationExpressionSyntax;
+            if (node == null)
+                return;
+
+            var arrayCreationExpression =
+                SyntaxFactory.ArrayCreationExpression(SyntaxFactory.Token(SyntaxKind.NewKeyword), null, null);      
             var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
             context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Replace with 'new'", document.WithSyntaxRoot(newRoot)), diagnostic);
         }

--- a/Tests/CSharp/Diagnostics/UseArrayCreationExpressionTests.cs
+++ b/Tests/CSharp/Diagnostics/UseArrayCreationExpressionTests.cs
@@ -4,7 +4,6 @@ using RefactoringEssentials.CSharp.Diagnostics;
 namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 {
     [TestFixture]
-    [Ignore("TODO: Issue not ported yet")]
     public class UseArrayCreationExpressionTests : CSharpDiagnosticTestBase
     {
         [Test]

--- a/Tests/CSharp/Diagnostics/UseArrayCreationExpressionTests.cs
+++ b/Tests/CSharp/Diagnostics/UseArrayCreationExpressionTests.cs
@@ -9,7 +9,7 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestTypeOfIsAssignableFrom()
         {
-            Test<UseArrayCreationExpressionAnalyzer>(@"
+            Analyze<UseArrayCreationExpressionAnalyzer>(@"
 class Test
 {
 	void Foo()
@@ -31,7 +31,7 @@ class Test
         [Test]
         public void MultiDim()
         {
-            Test<UseArrayCreationExpressionAnalyzer>(@"
+            Analyze<UseArrayCreationExpressionAnalyzer>(@"
 class Test
 {
 	void Foo(int i)


### PR DESCRIPTION
Fix most of the issues that were found by Mike Kreuger
I Have to check out the LiteralExpresion issue
Looking for a way to port the following piece of code :

            ////    var argRR = ctx.Resolve(invocationExpression.Arguments.ElementAt(1));
            ////    if (!argRR.Type.IsKnownType(KnownTypeCode.Int32))
            ////     return;

Moreover @mkrueger , could you refer me at one example where I have to create an array creation expression ? Looking for how to fix my code fix provider as it was not compiling due to a lack of information for its construction. 
Here's the snippet that's severely lacking in good code : 

            context.RegisterCodeFix(
    CodeActionFactory.Create(node.Span, diagnostic.Severity, "Convert to 'return' statement", token =>
    {
        var newArrayInstantiation = SyntaxFactory.ArrayCreationExpression(SyntaxFactory.Token(SyntaxKind.NewKeyword),
            null, null, null);
        var newRoot = root.ReplaceNode(node,
newArrayInstantiation.WithLeadingTrivia(node.GetLeadingTrivia())
         .WithAdditionalAnnotations(Formatter.Annotation));
        return Task.FromResult(document.WithSyntaxRoot(newRoot));
    }), diagnostic);

Thanks! 