### PR TITLE
C# IterateViaForeach tries to generate foreach for field declaration

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/IterateViaForeachAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/IterateViaForeachAction.cs
@@ -41,9 +41,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                 return;
             }
 
-            var variableDeclarator = node as VariableDeclaratorSyntax;
+            var variableDeclarator = node.GetAncestorOrThis<VariableDeclaratorSyntax>();
+            var localDeclaration = node.GetAncestor<LocalDeclarationStatementSyntax>();
 
-            if (variableDeclarator != null && IsEnumerable(model.GetDeclaredSymbol(variableDeclarator)) == true)
+            if (localDeclaration != null && variableDeclarator != null && IsEnumerable(model.GetDeclaredSymbol(variableDeclarator)) == true)
             {
                 context.RegisterRefactoring(Handle(document, span, root, node, SyntaxFactory.IdentifierName(variableDeclarator.Identifier), false));
                 return;

--- a/Tests/CSharp/CodeRefactorings/IterateViaForeachTests.cs
+++ b/Tests/CSharp/CodeRefactorings/IterateViaForeachTests.cs
@@ -344,7 +344,32 @@ class TestClass
 using System.Collections.Generic;
 class TestClass
 {
-    List<int> list = $new List<int>();
+    List<int> list$ = new List<int>();
+}");
+        }
+
+        [Test]
+        public void HandlesLocalDeclarationWithObjectCreation()
+        {
+            Test<IterateViaForeachAction>(@"
+using System.Collections.Generic;
+class TestClass
+{
+    void Method()
+    {
+        List<int> list = $new List<int>();
+    }
+}", @"
+using System.Collections.Generic;
+class TestClass
+{
+    void Method()
+    {
+        List<int> list = new List<int>();
+        foreach (var item in list)
+        {
+        }
+    }
 }");
         }
     }


### PR DESCRIPTION
C# Iterate via foreach refactoring was incorrectly detecting field declaration as variable declaration. 