### PR TITLE
Comments should be ignored when finding left of expression in if to ?: analyzer

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
@@ -54,7 +54,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             whenTrue = whenTrueExprStatement.Expression as AssignmentExpressionSyntax;
             whenFalse = whenFalseExprStatement.Expression as AssignmentExpressionSyntax;
             if (whenTrue == null || whenFalse == null || whenTrue.Kind() != whenFalse.Kind() ||
-                !whenTrue.Left.IsEquivalentTo(whenFalse.Left))
+                !SyntaxFactory.AreEquivalent(whenTrue.Left, whenFalse.Left))
                 return false;
 
             return true;

--- a/Tests/CSharp/Diagnostics/ConvertIfStatementToConditionalTernaryExpressionTests.cs
+++ b/Tests/CSharp/Diagnostics/ConvertIfStatementToConditionalTernaryExpressionTests.cs
@@ -132,6 +132,33 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         }
 
 
+
+
+        [Test]
+        public void TestCommentsIgnoredWhenFindingLeftOfExpression()
+        {
+            Analyze<ConvertIfStatementToConditionalTernaryExpressionAnalyzer>(@"
+    public class Class1
+    {
+        string DoIt(bool a)
+        {
+            string status;
+
+            $if$ (a)
+            {                
+                    // Comment
+                    status = ""A"";
+            }
+            else
+            {                
+                    // Different comment
+                    status = ""B"";              
+            }
+
+            return status;
+        }
+    }", issueToFix: 1);
+        }
     }
 }
 


### PR DESCRIPTION
Comments are wrongly included in the check for the left side of expressions in ConvertIfStatementToConditionalTernaryExpressionAnalyzer

To fix this, I have changed it to use SyntaxFactory.AreEquivalent instead of IsEquivalentTo. AreEquivalent ignores Trivia.

https://social.msdn.microsoft.com/Forums/vstudio/en-US/eff51118-d091-4b2b-b9b3-8999557d20eb/is-there-a-way-to-compare-syntax-nodes-ignoring-trivia?forum=roslyn
