### PR TITLE
?: is suggested for ifs with nested if/elses but should not be

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
@@ -29,14 +29,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             {
                 if (embeddedBlock.Statements.Count > 1)
                     return false;
-
-                var descendentExpressions = node.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>();
-
-                if (descendentExpressions.Count() > 1)
+                var childNodes = embeddedBlock.ChildNodes();
+                if (childNodes.Count() > 1)
                     return false;
-
-                whenTrueExprStatement = descendentExpressions.FirstOrDefault();
-
+                whenTrueExprStatement = childNodes.OfType<ExpressionStatementSyntax>().FirstOrDefault();
             }
             else
             {
@@ -48,13 +44,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             {
                 if (elseBlock.Statements.Count > 1)
                     return false;
-
-                var descendentExpressions = node.Else.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>();
-
-                if (descendentExpressions.Count() > 1)
+                var childNodes = elseBlock.ChildNodes();
+                if (childNodes.Count() > 1)
                     return false;
-
-                whenFalseExprStatement = descendentExpressions.FirstOrDefault();
+                whenFalseExprStatement = childNodes.OfType<ExpressionStatementSyntax>().FirstOrDefault();
             }
             else
             {

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider.cs
@@ -29,7 +29,14 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             {
                 if (embeddedBlock.Statements.Count > 1)
                     return false;
-                whenTrueExprStatement = node.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault();
+
+                var descendentExpressions = node.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>();
+
+                if (descendentExpressions.Count() > 1)
+                    return false;
+
+                whenTrueExprStatement = descendentExpressions.FirstOrDefault();
+
             }
             else
             {
@@ -41,7 +48,13 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             {
                 if (elseBlock.Statements.Count > 1)
                     return false;
-                whenFalseExprStatement = node.Else.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault();
+
+                var descendentExpressions = node.Else.Statement.DescendantNodesAndSelf().OfType<ExpressionStatementSyntax>();
+
+                if (descendentExpressions.Count() > 1)
+                    return false;
+
+                whenFalseExprStatement = descendentExpressions.FirstOrDefault();
             }
             else
             {

--- a/Tests/CSharp/Diagnostics/ConvertIfStatementToConditionalTernaryExpressionTests.cs
+++ b/Tests/CSharp/Diagnostics/ConvertIfStatementToConditionalTernaryExpressionTests.cs
@@ -131,7 +131,41 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 }");
         }
 
+        [Test]
+        public void TestSkipMultipleDescendantExpressions()
+        {
+            Analyze<ConvertIfStatementToConditionalTernaryExpressionAnalyzer>(@"
+    public class Class1
+    {
+        string DoIt(bool a, int b, int c)
+        {
+            string s;
+            bool z = false;
 
+            if (a)
+            {
+                if (b < c)
+                    s = ""a"";
+                else
+                {
+                    s = ""b"";
+                    z = true;
+                }
+            }
+            else
+            {
+                if (b > 0)
+                    s = ""c"";
+                else
+                {
+                    s = ""d"";
+                    z = true;
+                }
+            }
+            return s;
+        }
+    }");
+        }
     }
 }
 


### PR DESCRIPTION
ConvertIfStatementToConditionalTernaryExpressionCodeRefactoringProvider has a comment:

  //make sure to check for multiple statements

but multiple descendent expressions are also problematic. The effect of this is that ?: is suggested, but only the first of the descendent expressions is pulled through, causing a lot of code ot be potentially removed. It makes no sense to convert an if with nested if/else to be converted to ?: