### PR TITLE
Better checking if type symbol implements special type interface

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
@@ -28,7 +28,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             if (symbol == null)
                 yield break;
 
-            if (!IsDisposable(semanticModel, symbol.Type))
+            if (!symbol.Type.ImplementsSpecialTypeInterface(SpecialType.System_IDisposable))
                 yield break;
 
             var containingBlock = node.GetAncestor<BlockSyntax>();
@@ -184,21 +184,6 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
 
             return true;
-        }
-
-        private static bool IsDisposable(SemanticModel semanticModel, ITypeSymbol type)
-        {
-            var disposable = semanticModel.Compilation.GetSpecialType(SpecialType.System_IDisposable);
-
-            if (type.GetAllInterfacesIncludingThis().Contains(disposable))
-                return true;
-
-            var parameterType = type as ITypeParameterSymbol;
-
-            if (parameterType != null && parameterType.ConstraintTypes.Any(x => IsDisposable(semanticModel, x)))
-                return true;
-
-            return false;
         }
     }
 }

--- a/RefactoringEssentials/Util/ITypeSymbolExtensions.cs
+++ b/RefactoringEssentials/Util/ITypeSymbolExtensions.cs
@@ -51,6 +51,33 @@ namespace RefactoringEssentials
             }
         }
 
+        public static bool ImplementsSpecialTypeInterface(this ITypeSymbol symbol, SpecialType type)
+        {
+            if (symbol.SpecialType == type)
+            {
+                return true;
+            }
+
+            var namedType = symbol as INamedTypeSymbol;
+            if (namedType != null && namedType.IsGenericType && namedType != namedType.ConstructedFrom)
+            {
+                return namedType.ConstructedFrom.ImplementsSpecialTypeInterface(type);
+            }
+
+            var typeParam = symbol as ITypeParameterSymbol;
+            if (typeParam != null)
+            {
+                return typeParam.ConstraintTypes.Any(x => x.ImplementsSpecialTypeInterface(type));
+            }
+
+            if (symbol.AllInterfaces.Any(x => x.ImplementsSpecialTypeInterface(type)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public static TypeSyntax GenerateTypeSyntax(this ITypeSymbol typeSymbol)
         {
             return (TypeSyntax)generateTypeSyntax.Invoke(null, new[] { typeSymbol });

--- a/RefactoringEssentials/Util/ITypeSymbolExtensions.cs
+++ b/RefactoringEssentials/Util/ITypeSymbolExtensions.cs
@@ -1147,8 +1147,8 @@ namespace RefactoringEssentials
         }
 
         public static bool IsIEnumerable(this ITypeSymbol typeSymbol)
-        {            
-            return typeSymbol.GetAllInterfacesIncludingThis().Any(x => x.SpecialType == SpecialType.System_Collections_IEnumerable);
+        {
+            return typeSymbol.ImplementsSpecialTypeInterface(SpecialType.System_Collections_IEnumerable);
         }
     }
 }

--- a/Tests/SymbolChecksTest.cs
+++ b/Tests/SymbolChecksTest.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using NUnit.Framework;
+
+namespace RefactoringEssentials.Tests
+{
+    [TestFixture]
+    public class SymbolChecksTest
+    {
+        [Test]
+        public void DirectSpecialType()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System;
+class Test
+{
+    void Method(IDisposable a)
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void SpecialTypeAsGenericConstraint()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System;
+class Test
+{
+    void Method<T>(T a)
+        where T : IDisposable
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void InterfaceInheritingSpecialTypeAsGenericConstraint()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System;
+interface IInheritDisposable : IDisposable
+{
+
+}
+class Test
+{
+    void Method<T>(T a)
+        where T : IInheritDisposable
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void InterfaceInheritingSpecialTypeAsParameter()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System;
+interface IInheritDisposable : IDisposable
+{
+
+}
+class Test
+{
+    void Method(IInheritDisposable a)
+    {
+        var x = $a;
+    }
+}");
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void ClassInheritingImplementionOfSpecialTypeAsGenericConstraint()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System;
+interface IInheritDisposable : IDisposable
+{
+
+}
+
+class BaseClass : IInheritDisposable
+{
+    public void Dispose(){}
+}
+
+class Derived : BaseClass
+{}
+
+class Test
+{
+    void Method<T>(T a)
+        where T:Derived
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void ClassInheritingImplementionOfGenericSpecialTypeAsGenericConstraint()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+using System.Collections.Generic;
+interface IInheritEnumerable : IEnumerable<object>
+{
+
+}
+
+class BaseClass : IInheritEnumerable
+{
+    public IEnumerator<object> GetEnumerator()
+    {
+        return null;
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return null;
+    }
+}
+
+class Derived : BaseClass
+{}
+
+class Test
+{
+    void Method<T>(T a)
+        where T:Derived
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_Collections_Generic_IEnumerable_T), Is.True,
+                message: "Symbol is implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void LocallyDefinedDisposableNotDetectedAsSpecialType()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+interface IDisposable
+{}
+class Test
+{
+    void Method(IDisposable a)
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.False,
+                message: "Symbol is not implementing IDisposable"
+            );
+        }
+
+        [Test]
+        public void DoNotHangOnGenericTypes()
+        {
+            var symbol = FindSymbol<IParameterSymbol>(@"
+class Test
+{
+    void Method(System.IComparable<System.String> a)
+    {
+        var x = $a;
+    }
+}");
+
+            Assert.That(
+                symbol.GetSymbolType().ImplementsSpecialTypeInterface(SpecialType.System_IDisposable), Is.False,
+                message: "Symbol is not implementing IDisposable"
+            );
+        }
+
+        static TSymbol FindSymbol<TSymbol>(string code)
+            where TSymbol : ISymbol
+        {
+            var position = code.IndexOf('$');
+
+            var cleanedCode = code.Remove(position, 1);
+
+            var workspace = new DiagnosticTestBase.TestWorkspace();
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            var docInfo = DocumentInfo.Create(documentId, "Document1.cs", loader: TextLoader.From(TextAndVersion.Create(SourceText.From(cleanedCode), VersionStamp.Create())));
+
+            var mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+
+            var projectInfo = ProjectInfo.Create(
+                projectId,
+                VersionStamp.Create(),
+                "Project",
+                "Project",
+                LanguageNames.CSharp,
+                metadataReferences: new[] { mscorlib },
+                documents: new[] { docInfo }
+                );
+
+
+            workspace.Open(projectInfo);
+
+            var document = workspace.CurrentSolution.GetDocument(documentId);
+
+            var semanticModel = document.GetSemanticModelAsync().Result;
+
+            var diag = semanticModel.GetDiagnostics();
+
+            Assert.That(diag, Is.Empty, "No errors reported");
+
+            var symbol = SymbolFinder.FindSymbolAtPosition(semanticModel, position, workspace);
+
+            Assert.That(symbol, Is.Not.Null, "Symbol should be found");
+            Assert.That(symbol, Is.InstanceOf<TSymbol>());
+
+            return (TSymbol)symbol;
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -414,6 +414,7 @@
     <Compile Include="CSharp\CodeRefactorings\ConvertInterpolatedStringToStringFormatTests.cs" />
     <Compile Include="Common\DiagnosticTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SymbolChecksTest.cs" />
     <Compile Include="VB\CodeRefactorings\AddAnotherAccessorTests.cs" />
     <Compile Include="VB\CodeRefactorings\ComputeConstantValueTests.cs" />
     <Compile Include="VB\CodeRefactorings\ConvertToCustomEventTests.cs" />


### PR DESCRIPTION
When I was working on PutInsideUsing and IterateViaForeach refactorings I noticed that checking if type symbol is `IDisposable` or `IEnumerable` is tricky. 

This pull request adds mechanism to check if type symbol implements specific special type interface and updates both refactorings to use it.