### PR TITLE
Fixed build on Windows.

### DIFF
--- a/RefactoringEssentials/RefactoringEssentials.csproj
+++ b/RefactoringEssentials/RefactoringEssentials.csproj
@@ -608,7 +608,8 @@
     <None Include="CodeAnalyzers.html.template" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />


### PR DESCRIPTION
The RefactoringEssentials project was refering to analyzers from the Microsoft.CodeAnalysis.Analyzers 1.0.0-rc2 when version 1.0.0 is being used. On a clean machine without any existing NuGet packages restored the build would fail with a Metadata file could not be found refering to the Analyzer dll.