### PR TITLE
Mark analyser package as a development-only dependency.

### DIFF
--- a/RefactoringEssentials/RefactoringEssentials.nuspec
+++ b/RefactoringEssentials/RefactoringEssentials.nuspec
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0"?>
-
 <package>
-	<metadata>
+	<metadata minClientVersion="2.8">
 		<id>RefactoringEssentials</id>
 		<version>1.2.0</version>
 		<title>Refactoring Essentials</title>
@@ -15,6 +14,7 @@
 		<releaseNotes>First release for Visual Studio 2015 RTM, some bug fixes and new VB refactorings.</releaseNotes>
 		<copyright>Copyright (c) 2014-2015 AlphaSierraPapa</copyright>
 		<tags>VS 2015 Roslyn Analyzer Refactoring</tags>
+		<developmentDependency>true</developmentDependency>
 	</metadata>
 	<files>
 		<file src="RefactoringEssentials.dll" target="analyzers\dotnet\" />

--- a/RefactoringEssentials/RefactoringEssentials.tt
+++ b/RefactoringEssentials/RefactoringEssentials.tt
@@ -4,7 +4,7 @@
 <#@ include file="Versioning.t4.template" #>
 <# ReadVersions(Path.Combine(Path.GetDirectoryName(Host.TemplateFile), "RefactoringEssentials.version")); #>
 <package>
-	<metadata>
+	<metadata minClientVersion="2.8">
 		<id>RefactoringEssentials</id>
 		<version><#= generatedNuGetVersion #></version>
 		<title>Refactoring Essentials</title>
@@ -18,6 +18,7 @@
 		<releaseNotes>First release for Visual Studio 2015 RTM, some bug fixes and new VB refactorings.</releaseNotes>
 		<copyright>Copyright (c) 2014-2015 AlphaSierraPapa</copyright>
 		<tags>VS 2015 Roslyn Analyzer Refactoring</tags>
+		<developmentDependency>true</developmentDependency>
 	</metadata>
 	<files>
 		<file src="RefactoringEssentials.dll" target="analyzers\dotnet\" />


### PR DESCRIPTION
Without this change, packages built from projects will include RefactoringEssentials as a dependency of their package.