### PR TITLE
C# Merge Nested If - complex condition joining bug

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/MergeNestedIfAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/MergeNestedIfAction.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 
 namespace RefactoringEssentials.CSharp.CodeRefactorings
@@ -43,13 +44,26 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
             yield return CodeActionFactory.Create(span, DiagnosticSeverity.Info, "Merged nested 'if'", ct =>
             {
-                var newCondition = SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, outerIf.Condition, innerIf.Condition);
+                var innerCondition = SyntaxFactory.ParenthesizedExpression(innerIf.Condition);
+                var outerCondition = SyntaxFactory.ParenthesizedExpression(outerIf.Condition);
+
+                var newCondition = SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, outerCondition, innerCondition);
+
+                if (((ParenthesizedExpressionSyntax)newCondition.Right).CanRemoveParentheses())
+                {
+                    newCondition = newCondition.ReplaceNode(newCondition.Right, innerCondition.Expression);
+                }
+
+                if (((ParenthesizedExpressionSyntax)newCondition.Left).CanRemoveParentheses())
+                {
+                    newCondition = newCondition.ReplaceNode(newCondition.Left, outerCondition.Expression);
+                }
 
                 var newIf = SyntaxFactory.IfStatement(newCondition, innerIf.Statement)
                     .WithAdditionalAnnotations(Formatter.Annotation);
 
                 var newRoot = root.ReplaceNode(outerIf, newIf);
-
+                
                 return Task.FromResult(document.WithSyntaxRoot(newRoot));
             });
         }

--- a/Tests/CSharp/CodeRefactorings/MergeNestedIfTests.cs
+++ b/Tests/CSharp/CodeRefactorings/MergeNestedIfTests.cs
@@ -195,5 +195,61 @@ class TestClass
     }
 }");
         }
+
+        [Test]
+        public void TestInnerIfWithComplexCondition()
+        {
+            Test<MergeNestedIfAction>(@"
+class TestClass
+{
+    int TestMethod (int a)
+    {
+        if (a > 0) {
+
+        {
+            $if (a < 5 || a < 10) 
+                return 1;
+        }
+
+        }
+    }
+}", @"
+class TestClass
+{
+    int TestMethod (int a)
+    {
+        if (a > 0 && (a < 5 || a < 10))
+            return 1;
+    }
+}");
+        }
+
+        [Test]
+        public void TestOuterIfWithComplexCondition()
+        {
+            Test<MergeNestedIfAction>(@"
+class TestClass
+{
+    int TestMethod (int a)
+    {
+        if (a > 0 || a < 10) {
+
+        {
+            $if (a < 5) 
+                return 1;
+        }
+
+        }
+    }
+}", @"
+class TestClass
+{
+    int TestMethod (int a)
+    {
+        if ((a > 0 || a < 10) && a < 5)
+            return 1;
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
Merging nested if with complex condition in inner or outer if could change effective condition because no parentheses were added.