### PR TITLE
Virtual calls from closures should be allowed in ctors

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/DoNotCallOverridableMethodsInConstructorAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/DoNotCallOverridableMethodsInConstructorAnalyzer.cs
@@ -122,6 +122,16 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                 Check(node);
             }
 
+            public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+            {
+                // delegates with virtual calls are allowed
+            }
+
+            public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+            {
+                // arrow expressions with virtual calls are allowed
+            }
+
             static bool IsSimpleThisCall(ExpressionSyntax expression)
             {
                 var ma = expression as MemberAccessExpressionSyntax;


### PR DESCRIPTION
Constructor should be allowed to invoke a virtual member in cases where it's creating a thread, a callback and similar continuation call.

```csharp
class Button
{
    public Button()
    {
        this.Click += delegate { this.Refresh(); }; // no sense check for virtual calls inside callbacks
    }
}
```

This patch skips delegates and arrow expressions.