### PR TITLE
Fix renamed type for VS2015.1, fixes #124

### DIFF
--- a/RefactoringEssentials/Util/SyntaxExtensions.cs
+++ b/RefactoringEssentials/Util/SyntaxExtensions.cs
@@ -46,9 +46,13 @@ namespace RefactoringEssentials
             typeInfo = Type.GetType("Microsoft.CodeAnalysis.CSharp.Extensions.MemberDeclarationSyntaxExtensions+LocalDeclarationMap" + ReflectionNamespaces.CSWorkspacesAsmName, true);
             localDeclarationMapIndexer = typeInfo.GetProperties().Single(p => p.GetIndexParameters().Any());
 
-            typeInfo = Type.GetType("Microsoft.CodeAnalysis.Shared.Extensions.CommonSyntaxTokenExtensions" + ReflectionNamespaces.WorkspacesAsmName, true);
+            typeInfo = Type.GetType("Microsoft.CodeAnalysis.Shared.Extensions.CommonSyntaxTokenExtensions" + ReflectionNamespaces.WorkspacesAsmName);
+            if (typeInfo == null)
+            {
+                //the type has been renamed in Update 1
+                typeInfo = Type.GetType("Microsoft.CodeAnalysis.Shared.Extensions.SyntaxTokenExtensions" + ReflectionNamespaces.WorkspacesAsmName, true);
+            }
             getAncestorsMethod = typeInfo.GetMethods().Single(m => m.Name == "GetAncestors" && m.IsGenericMethod);
-
         }
 
 


### PR DESCRIPTION
The type has been renamed in Update 1, this introduces a fallback to not fail when used in Update 1