### PR TITLE
Migrated C# ReplaceWithStringIsNullOrEmpty Analyzer, issue #130

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/ReplaceWithStringIsNullOrEmptyAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/ReplaceWithStringIsNullOrEmptyAnalyzer.cs
@@ -1,5 +1,11 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using RefactoringEssentials;
+using RefactoringEssentials.Util;
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace RefactoringEssentials.CSharp.Diagnostics
@@ -9,71 +15,12 @@ namespace RefactoringEssentials.CSharp.Diagnostics
     /// Converts to: string.IsNullOrEmpty (str)
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [NotPortedYet]
     public class ReplaceWithStringIsNullOrEmptyAnalyzer : DiagnosticAnalyzer
     {
-        //		static readonly Pattern pattern = new Choice {
-        //			// str == null || str == ""
-        //			// str == null || str.Length == 0
-        //			new BinaryOperatorExpression (
-        //				PatternHelper.CommutativeOperatorWithOptionalParentheses (new AnyNode ("str"), BinaryOperatorType.Equality, new NullReferenceExpression ()),
-        //				BinaryOperatorType.ConditionalOr,
-        //				new Choice {
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new Backreference ("str"), BinaryOperatorType.Equality, new PrimitiveExpression ("")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new Backreference ("str"), BinaryOperatorType.Equality,
-        //				                                       new PrimitiveType("string").Member("Empty")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (
-        //						new MemberReferenceExpression (new Backreference ("str"), "Length"),
-        //						BinaryOperatorType.Equality,
-        //						new PrimitiveExpression (0)
-        //					)
-        //				}
-        //			),
-        //			// str == "" || str == null
-        //			new BinaryOperatorExpression (
-        //				new Choice {
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new AnyNode ("str"), BinaryOperatorType.Equality, new PrimitiveExpression ("")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new AnyNode ("str"), BinaryOperatorType.Equality,
-        //				                                       new PrimitiveType("string").Member("Empty"))
-        //				},
-        //				BinaryOperatorType.ConditionalOr,
-        //				PatternHelper.CommutativeOperator(new Backreference ("str"), BinaryOperatorType.Equality, new NullReferenceExpression ())
-        //			)
-        //		};
-        //		static readonly Pattern negPattern = new Choice {
-        //			// str != null && str != ""
-        //			// str != null && str.Length != 0
-        //			// str != null && str.Length > 0
-        //			new BinaryOperatorExpression (
-        //				PatternHelper.CommutativeOperatorWithOptionalParentheses(new AnyNode ("str"), BinaryOperatorType.InEquality, new NullReferenceExpression ()),
-        //				BinaryOperatorType.ConditionalAnd,
-        //				new Choice {
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new Backreference ("str"), BinaryOperatorType.InEquality, new PrimitiveExpression ("")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new Backreference ("str"), BinaryOperatorType.InEquality,
-        //				                                   	   new PrimitiveType("string").Member("Empty")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (
-        //						new MemberReferenceExpression (new Backreference ("str"), "Length"),
-        //						BinaryOperatorType.InEquality,
-        //						new PrimitiveExpression (0)
-        //					),
-        //					new BinaryOperatorExpression (
-        //						new MemberReferenceExpression (new Backreference ("str"), "Length"),
-        //						BinaryOperatorType.GreaterThan,
-        //						new PrimitiveExpression (0)
-        //					)
-        //				}
-        //			),
-        //			// str != "" && str != null
-        //			new BinaryOperatorExpression (
-        //				new Choice {
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new AnyNode ("str"), BinaryOperatorType.InEquality, new PrimitiveExpression ("")),
-        //					PatternHelper.CommutativeOperatorWithOptionalParentheses (new AnyNode ("str"), BinaryOperatorType.Equality,
-        //				                                   	   new PrimitiveType("string").Member("Empty"))
-        //				},
-        //				BinaryOperatorType.ConditionalAnd,
-        //				PatternHelper.CommutativeOperatorWithOptionalParentheses(new Backreference ("str"), BinaryOperatorType.InEquality, new NullReferenceExpression ())
-        //			)
-        //		};
+        /// <summary>
+        /// The name of the property referred to by the <see cref="Diagnostic"/> for the replacement code.
+        /// </summary>
+        public static readonly string ReplacementPropertyName = "Replacement";
 
         static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
             CSharpDiagnosticIDs.ReplaceWithStringIsNullOrEmptyAnalyzerID,
@@ -89,15 +36,18 @@ namespace RefactoringEssentials.CSharp.Diagnostics
 
         public override void Initialize(AnalysisContext context)
         {
-            //context.RegisterSyntaxNodeAction(
-            //	(nodeContext) => {
-            //		Diagnostic diagnostic;
-            //		if (TryGetDiagnostic (nodeContext, out diagnostic)) {
-            //			nodeContext.ReportDiagnostic(diagnostic);
-            //		}
-            //	}, 
-            //	new SyntaxKind[] { SyntaxKind.None }
-            //);
+            context.RegisterSyntaxNodeAction(
+                (nodeContext) =>
+                {
+                    Diagnostic diagnostic;
+                    if (TryGetDiagnostic(nodeContext, out diagnostic))
+                    {
+                        nodeContext.ReportDiagnostic(diagnostic);
+                    }
+                },
+                SyntaxKind.LogicalAndExpression,
+                SyntaxKind.LogicalOrExpression
+            );
         }
 
         static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
@@ -105,53 +55,345 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             diagnostic = default(Diagnostic);
             if (nodeContext.IsFromGeneratedCode())
                 return false;
-            //var node = nodeContext.Node as ;
-            //diagnostic = Diagnostic.Create (descriptor, node.GetLocation ());
-            //return true;
+
+            var node = nodeContext.Node as BinaryExpressionSyntax;
+
+            // Must be of binary expression of 2 binary expressions.
+            if (!node.IsKind(SyntaxKind.LogicalAndExpression, SyntaxKind.LogicalOrExpression))
+                return false;
+
+            // Verify left is a binary expression.
+            var left = SimplifySyntax(node.Left) as BinaryExpressionSyntax;
+            if (left == null)
+                return false;
+
+            // Verify right is a binary expression.
+            var right = SimplifySyntax(node.Right) as BinaryExpressionSyntax;
+            if (right == null)
+                return false;
+
+            // Ensure left and right are binary and not assignment.
+            if (!SyntaxFacts.IsBinaryExpression(left.OperatorToken.Kind()) || !SyntaxFacts.IsBinaryExpression(right.OperatorToken.Kind()))
+                return false;
+
+            // Test if left and right are suitable for replacement.
+            var leftReplace = ShouldReplace(nodeContext, left);
+            var rightReplace = ShouldReplace(nodeContext, right);
+
+            // Test both are suitable for replacement.
+            if (!leftReplace.ShouldReplace || !rightReplace.ShouldReplace)
+                return false;
+
+            // Test that both are either positive or negative tests.
+            if (!(leftReplace.IsNegative == rightReplace.IsNegative))
+                return false;
+
+            // Ensure that one tests for null and the other tests for empty.
+            var isNullOrEmptyTest = (leftReplace.IsNullTest && rightReplace.IsEmptyTest) || (leftReplace.IsEmptyTest && rightReplace.IsNullTest);
+
+            if (!isNullOrEmptyTest)
+                return false;
+
+            // Ensure that both refer to the same identifier.
+            // Good: foo != null && foo != ""
+            // Bad: foo != null && bar != ""
+            if (!string.Equals(leftReplace.IdentifierNode.ToString(),
+                rightReplace.IdentifierNode.ToString(),
+                StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            // Generate replacement string and negate if necessary.
+            // Used within diagnostic message and also passed down for replacement.
+            var replacementString = string.Format("string.IsNullOrEmpty({0})", leftReplace.IdentifierNode);
+
+            if (leftReplace.IsNegative)
+                replacementString = "!" + replacementString;
+
+            // We already did the work now pass it down to the code fix provider via a property.
+            var props = new Dictionary<string, string>
+                {
+                    { ReplacementPropertyName, replacementString }
+                };
+
+            diagnostic = Diagnostic.Create(
+                descriptor,
+                node.GetLocation(),
+                ImmutableDictionary.CreateRange(props),
+                replacementString);
+            return true;
+        }
+
+        /// <summary>
+        /// Indicates whether a binary expression is suitable for replacement and info about it.
+        /// </summary>
+        class ShouldReplaceResult
+        {
+            /// <summary>
+            /// Is the expression suitable for replacement.
+            /// </summary>
+            public bool ShouldReplace { get; set; } = false;
+
+            /// <summary>
+            /// Is the expression a test for null?
+            /// </summary>
+            public bool IsNullTest { get; set; } = false;
+
+            /// <summary>
+            /// Is the expression a test for empty?
+            /// </summary>
+            public bool IsEmptyTest { get; set; } = false;
+
+            /// <summary>
+            /// Is the expression negated?
+            /// </summary>
+            public bool IsNegative { get; set; } = false;
+
+            /// <summary>
+            /// What string symbol is being tested for null or empty?
+            /// </summary>
+            public ExpressionSyntax IdentifierNode { get; set; } = null;
+
+        }
+
+        /// <summary>
+        /// Test whether a binary expression is suitable for replacement. 
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ShouldReplaceResult"/> indicating whether the node is suitable for replacement.
+        /// </returns>
+        static ShouldReplaceResult ShouldReplace(SyntaxNodeAnalysisContext nodeContext, BinaryExpressionSyntax node)
+        {
+            // input (left, right, operator) output Result
+            var left = SimplifySyntax(node.Left);
+            var right = SimplifySyntax(node.Right);
+
+            // str ==
+            if (IsStringSyntax(nodeContext, left))
+            {
+                return ShouldReplaceString(nodeContext, left, right, node.OperatorToken);
+            }
+
+            // == str
+            if (IsStringSyntax(nodeContext, right))
+            {
+                return ShouldReplaceString(nodeContext, right, left, node.OperatorToken);
+            }
+
+            // str.Length ==
+            if (IsStringLengthSyntax(nodeContext, left))
+            {
+                return ShouldReplaceStringLength(left as MemberAccessExpressionSyntax, right, node.OperatorToken);
+            }
+
+            // == str.Length
+            if (IsStringLengthSyntax(nodeContext, right))
+            {
+                return ShouldReplaceStringLength(right as MemberAccessExpressionSyntax, left, node.OperatorToken);
+            }
+
+            // We did not find a suitable replacement.
+            return new ShouldReplaceResult
+            {
+                ShouldReplace = false
+            };
+        }
+
+        /// <summary>
+        /// Determine whether a binary expression with a string expression is suitable for replacement.
+        /// </summary>
+        /// <param name="left">A node representing a string expression.</param>
+        /// <param name="right">A node to be tested.</param>
+        /// <param name="operatorToken">The operator separating the nodes.</param>
+        /// <returns></returns>
+        static ShouldReplaceResult ShouldReplaceString(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
+        {
+            var result = new ShouldReplaceResult();
+            result.ShouldReplace = false;
+
+            // str == null or str != null
+            if (IsNullSyntax(nodeContext, right))
+            {
+                result.IsNullTest = true;
+                result.ShouldReplace = true;
+            }
+            // str == "" or str != ""
+            // str == string.Empty or str != string.Empty
+            else if (IsEmptySyntax(nodeContext, right))
+            {
+                result.IsEmptyTest = true;
+                result.ShouldReplace = true;
+            }
+
+            if (result.ShouldReplace)
+            {
+                result.IdentifierNode = left;
+
+                if (operatorToken.IsKind(SyntaxKind.ExclamationEqualsToken))
+                {
+                    result.IsNegative = true;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Determines whether a binary expression with a string length expression is suitable for replacement.
+        /// </summary>
+        /// <param name="left">A node representing a string length expression.</param>
+        /// <param name="right">A node to be tested.</param>
+        /// <param name="operatorToken">The operator separating the nodes.</param>
+        /// <returns></returns>
+        static ShouldReplaceResult ShouldReplaceStringLength(MemberAccessExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
+        {
+            const string zeroLiteral = "0";
+            const string oneLiteral = "1";
+
+            var result = new ShouldReplaceResult();
+            result.ShouldReplace = false;
+
+            // str.Length == 0 or str.Length <= 0
+            if (operatorToken.IsKind(SyntaxKind.EqualsEqualsToken, SyntaxKind.LessThanEqualsToken) && string.Equals(zeroLiteral, right.ToString()))
+            {
+                result.IsEmptyTest = true;
+                result.ShouldReplace = true;
+            }
+            // str.Length < 1
+            else if (operatorToken.IsKind(SyntaxKind.LessThanToken) && string.Equals(oneLiteral, right.ToString()))
+            {
+                result.IsEmptyTest = true;
+                result.ShouldReplace = true;
+            }
+            // str.Length != 0 or str.Length > 0
+            else if (operatorToken.IsKind(SyntaxKind.ExclamationEqualsToken, SyntaxKind.GreaterThanToken) && string.Equals(zeroLiteral, right.ToString()))
+            {
+                result.IsEmptyTest = true;
+                result.IsNegative = true;
+                result.ShouldReplace = true;
+            }
+            // str.Length >= 1
+            else if (operatorToken.IsKind(SyntaxKind.GreaterThanEqualsToken) && string.Equals(oneLiteral, right.ToString()))
+            {
+                result.IsEmptyTest = true;
+                result.IsNegative = true;
+                result.ShouldReplace = true;
+            }
+
+            if (result.ShouldReplace)
+            {
+                result.IdentifierNode = left.Expression;
+            }
+
+            return result;
+
+        }
+
+        /// <summary>
+        /// Does the expression look like a string type?
+        /// </summary>
+        static bool IsStringSyntax(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax node)
+        {
+            if (!IsStringType(nodeContext, node))
+                return false;
+
+            return node.IsKind(SyntaxKind.IdentifierName, SyntaxKind.InvocationExpression, SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        /// <summary>
+        /// Does the expression look like a string length call?
+        /// </summary>
+        static bool IsStringLengthSyntax(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            {
+                var smaNode = node as MemberAccessExpressionSyntax;
+
+                if (smaNode.Name.Identifier.Text == "Length")
+                {
+                    if (!IsStringType(nodeContext, smaNode.Expression))
+                        return false;
+
+                    return true;
+                }
+            }
+
             return false;
         }
 
-        //		class GatherVisitor : GatherVisitorBase<ReplaceWithStringIsNullOrEmptyAnalyzer>
-        //		{
-        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-        //				: base (semanticModel, addDiagnostic, cancellationToken)
-        //			{
-        //			}
-        ////
-        ////			public override void VisitBinaryOperatorExpression(BinaryOperatorExpression binaryOperatorExpression)
-        ////			{
-        ////				base.VisitBinaryOperatorExpression(binaryOperatorExpression);
-        ////				Match m = pattern.Match(binaryOperatorExpression);
-        ////				bool isNegated = false;
-        ////				if (!m.Success) {
-        ////					m = negPattern.Match(binaryOperatorExpression);
-        ////					isNegated = true;
-        ////				}
-        ////				if (m.Success) {
-        ////					var str = m.Get<Expression>("str").Single();
-        ////					var def = ctx.Resolve(str).Type.GetDefinition();
-        ////					if (def == null || def.KnownTypeCode != ICSharpCode.NRefactory.TypeSystem.KnownTypeCode.String)
-        ////						return;
-        ////					AddDiagnosticAnalyzer(new CodeIssue(
-        ////						binaryOperatorExpression,
-        //			//						isNegated ? ctx.TranslateString("Expression can be replaced with !string.IsNullOrEmpty") : ctx.TranslateString(""),
-        ////						new CodeAction (
-        //			//							isNegated ? ctx.TranslateString("Use !string.IsNullOrEmpty") : ctx.TranslateString("Use string.IsNullOrEmpty"),
-        ////							script => {
-        ////								Expression expr = new PrimitiveType("string").Invoke("IsNullOrEmpty", str.Clone());
-        ////								if (isNegated)
-        ////									expr = new UnaryOperatorExpression(UnaryOperatorType.Not, expr);
-        ////								script.Replace(binaryOperatorExpression, expr);
-        ////							},
-        ////							binaryOperatorExpression
-        ////						)
-        ////					));
-        ////					return;
-        ////				}
-        ////			}
-        ////	
-        //		}
+        /// <summary>
+        /// Does the expression look like a null?
+        /// </summary>
+        static bool IsNullSyntax(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax node)
+        {
+            if (!IsStringType(nodeContext, node))
+                return false;
+
+            return node.IsKind(SyntaxKind.NullLiteralExpression);
+        }
+
+        /// <summary>
+        /// Does the expression look like a test for empty string ("" or string.Empty)?
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        static bool IsEmptySyntax(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax node)
+        {
+            if (!IsStringType(nodeContext, node))
+                return false;
+
+            if (node.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                if (string.Equals("\"\"", node.ToString()))
+                    return true;
+            }
+            else if (node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            {
+                var sma = node as MemberAccessExpressionSyntax;
+
+                if (!string.Equals("string", sma.Expression.ToString(), StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!string.Equals("Empty", sma.Name.ToString(), StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Test if expression is a string type.
+        /// </summary>
+        static bool IsStringType(SyntaxNodeAnalysisContext nodeContext, ExpressionSyntax node)
+        {
+            var typeInfo = nodeContext.SemanticModel.GetTypeInfo(node);
+
+            if (typeInfo.ConvertedType == null)
+                return false;
+
+            if (!string.Equals("String", typeInfo.ConvertedType.Name, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Simplify an <see cref="ExpressionSyntax"/> by removing unecessary parenthesis.
+        /// </summary>
+        /// <returns>
+        /// A simplified <see cref="ExpressionSyntax"/>.
+        /// </returns>
+        static ExpressionSyntax SimplifySyntax(ExpressionSyntax syntax)
+        {
+            if (syntax.IsKind(SyntaxKind.ParenthesizedExpression))
+            {
+                syntax = (syntax as ParenthesizedExpressionSyntax).Expression;
+
+                syntax = SimplifySyntax(syntax);
+            }
+
+            return syntax;
+        }
     }
-
-
 }

--- a/RefactoringEssentials/CodeAnalyzers.CSharp.html
+++ b/RefactoringEssentials/CodeAnalyzers.CSharp.html
@@ -15,7 +15,7 @@
 
     -->
     <h2>Supported Code Analyzers</h2>
-    <p>99 code analyzers for C#</p>
+    <p>100 code analyzers for C#</p>
     <ul>
       <li>Suggests using the class declaring a static function when calling it (AccessToStaticMemberViaDerivedTypeAnalyzer)</li>
       <li>When initializing explicitly typed local variable or array type, array creation expression can be replaced with array initializer. (ArrayCreationCanBeReplacedWithArrayInitializerAnalyzer)</li>
@@ -106,6 +106,7 @@
       <li>Redundant Where() call with predicate followed by LongCount() (ReplaceWithSingleCallToLongCountAnalyzer)</li>
       <li>Redundant Where() call with predicate followed by Single() (ReplaceWithSingleCallToSingleAnalyzer)</li>
       <li>Redundant Where() call with predicate followed by SingleOrDefault() (ReplaceWithSingleCallToSingleOrDefaultAnalyzer)</li>
+      <li>Uses shorter string.IsNullOrEmpty call instead of a longer condition (ReplaceWithStringIsNullOrEmptyAnalyzer)</li>
       <li>'sealed' modifier is redundant in sealed classes (SealedMemberInSealedClassAnalyzer)</li>
       <li>Conditional expression can be simplified (SimplifyConditionalTernaryExpressionAnalyzer)</li>
       <li>Warns when a culture-aware 'string.CompareTo' call is used by default (StringCompareToIsCultureSpecificAnalyzer)</li>

--- a/RefactoringEssentials/missing.md
+++ b/RefactoringEssentials/missing.md
@@ -74,7 +74,6 @@
 * RedundantToStringCallAnalyzer
 * RedundantUnsafeContextAnalyzer
 * ReferenceEqualsWithValueTypeAnalyzer
-* ReplaceWithStringIsNullOrEmptyAnalyzer
 * SimplifyLinqExpressionAnalyzer
 * StaticEventSubscriptionAnalyzer
 * StaticFieldInGenericTypeAnalyzer

--- a/Tests/CSharp/Diagnostics/ReplaceWithStringIsNullOrEmptyTests.cs
+++ b/Tests/CSharp/Diagnostics/ReplaceWithStringIsNullOrEmptyTests.cs
@@ -4,25 +4,68 @@ using RefactoringEssentials.CSharp.Diagnostics;
 namespace RefactoringEssentials.Tests.CSharp.Diagnostics
 {
     [TestFixture]
-    [Ignore("TODO: Issue not ported yet")]
     public class ReplaceWithStringIsNullOrEmptyTests : CSharpDiagnosticTestBase
     {
         [Test]
+        public void TestMemberAccessCase()
+        {
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(
+                @"
+class Foo
+{
+	void Bar ()
+	{
+        var str = new { Name = ""John"" };
+		if ($str.Name != null && str.Name != """"$);
+	}
+}", @"
+class Foo
+{
+	void Bar ()
+	{
+        var str = new { Name = ""John"" };
+		if (!string.IsNullOrEmpty(str.Name));
+	}
+}");
+        }
+
+        [Test]
+        public void TestToStringCase()
+        {
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(
+                @"
+using System.Text;
+class Foo
+{
+	void Bar (StringBuilder str)
+	{
+		if ($str.ToString() != null && str.ToString() != """"$);
+	}
+}", @"
+using System.Text;
+class Foo
+{
+	void Bar (StringBuilder str)
+	{
+		if (!string.IsNullOrEmpty(str.ToString()));
+	}
+}");
+        }
+
+        [Test]
         public void TestInspectorCaseNS1()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str != null && str != """")
-			;
+		if ($str != null && str != """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -30,19 +73,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS2()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null != str && str != """")
-			;
+		if ($null != str && str != """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -50,19 +91,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorNegatedStringEmpty()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null != str && str != string.Empty)
-			;
+		if ($null != str && str != string.Empty$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -70,19 +109,35 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorStringEmpty()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null == str || str == string.Empty)
-			;
+		if ($null == str || str == string.Empty$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
+	}
+}");
+        }
+
+        [Test]
+        public void TestInspectorStringEmptyAlt()
+        {
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+{
+	void Bar (string str)
+	{
+		if ($str == string.Empty || null == str$);
+	}
+}", @"class Foo
+{
+	void Bar (string str)
+	{
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -90,19 +145,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS3()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null != str && """" != str)
-			;
+		if ($null != str && """" != str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -110,19 +163,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS4()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str != null && str != """")
-			;
+		if ($str != null && str != """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -130,19 +181,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN1()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str != """" && str != null)
-			;
+		if ($str != """" && str != null$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -150,19 +199,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN2()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if ("""" != str && str != null)
-			;
+		if ($"""" != str && str != null$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -170,19 +217,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN3()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if ("""" != str && null != str)
-			;
+		if ($"""" != str && null != str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -191,19 +236,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN4()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str != """" && null != str)
-			;
+		if ($str != """" && null != str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -211,19 +254,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS5()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str == null || str == """")
-			;
+		if ($str == null || str == """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -231,19 +272,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS6()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null == str || str == """")
-			;
+		if ($null == str || str == """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -251,19 +290,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS7()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (null == str || """" == str)
-			;
+		if ($null == str || """" == str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -271,19 +308,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseNS8()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str == null || """" == str)
-			;
+		if ($str == null || """" == str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -291,19 +326,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN5()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str == """" || str == null)
-			;
+		if ($str == """" || str == null$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -311,19 +344,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN6()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if ("""" == str || str == null)
-			;
+		if ($"""" == str || str == null$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -331,19 +362,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN7()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if ("""" == str || null == str)
-			;
+		if ($"""" == str || null == str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -351,19 +380,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [Test]
         public void TestInspectorCaseSN8()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (str == """" || null == str)
-			;
+		if ($str == """" || null == str$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -374,19 +401,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [TestCase("null == str || 0 == str.Length")]
         public void TestInspectorCaseNL(string expression)
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (" + expression + @")
-			;
+		if ($" + expression + @"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (string.IsNullOrEmpty (str))
-			;
+		if (string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -399,19 +424,17 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         [TestCase("null != str && str.Length > 0")]
         public void TestInspectorCaseLN(string expression)
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if (" + expression + @")
-			;
+		if ($" + expression + @"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }
@@ -431,21 +454,36 @@ namespace RefactoringEssentials.Tests.CSharp.Diagnostics
         }
 
         [Test]
+        public void TestLists()
+        {
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"
+using System.Collections.Generic;
+
+class Foo
+{
+	void Bar ()
+	{
+		var foo = new List<string>();
+		if (foo == null || foo.Length == 0) {
+		}
+	}
+}");
+        }
+
+        [Test]
         public void TestInspectorCaseNS1WithParentheses()
         {
-            Test<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
+            Analyze<ReplaceWithStringIsNullOrEmptyAnalyzer>(@"class Foo
 {
 	void Bar (string str)
 	{
-		if ((str != null) && (str) != """")
-			;
+		if ($(str != null) && (str) != """"$);
 	}
 }", @"class Foo
 {
 	void Bar (string str)
 	{
-		if (!string.IsNullOrEmpty (str))
-			;
+		if (!string.IsNullOrEmpty(str));
 	}
 }");
         }


### PR DESCRIPTION
In reference to issue #130; I migrated the ReplaceWithStringIsNullOrEmptyAnalyzer C# analyzer.
All unit tests pass and a few have been added.
Because pattern matching has not been ported over from NRefactory, I was unable to reuse prior patterns and resorted to coded matching.
Perhaps pattern matching can be ported from NRefactory to speed up migrations?

Thx.
Chuck