### PR TITLE
Add a ContractRequiresNotNull refactoring

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ContractRequiresNotNullCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ContractRequiresNotNullCodeRefactoringProvider.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using System.Threading;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace RefactoringEssentials.CSharp.CodeRefactorings
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = "Add a Contract to specify the paramter must not be null")]
+    /// <summary>
+    /// Creates a 'Contract.Requires(param != null);' contruct for a parameter.
+    /// </summary>
+    public class ContractRequiresNotNullCodeRefactoringProvider : SpecializedCodeRefactoringProvider<ParameterSyntax>
+    {
+        protected override IEnumerable<CodeAction> GetActions(Document document, SemanticModel semanticModel, SyntaxNode root, TextSpan span, ParameterSyntax node, CancellationToken cancellationToken)
+        {
+            if (!node.Identifier.Span.Contains(span))
+                return Enumerable.Empty<CodeAction>();
+            var parameter = node;
+            var bodyStatement = parameter.Parent.Parent.ChildNodes().OfType<BlockSyntax>().FirstOrDefault();
+            if (bodyStatement == null)
+                return Enumerable.Empty<CodeAction>();
+
+            var parameterSymbol = semanticModel.GetDeclaredSymbol(node);
+            var type = parameterSymbol.Type;
+            if (type == null || type.IsValueType || HasNotNullContract(semanticModel, parameterSymbol, bodyStatement))
+                return Enumerable.Empty<CodeAction>();
+            return new[] { CodeActionFactory.Create(
+                node.Identifier.Span,
+                DiagnosticSeverity.Info,
+                GettextCatalog.GetString ("Add contract requires parameter must not be null"),
+                t2 => {
+                    var newBody = bodyStatement.WithStatements (SyntaxFactory.List<StatementSyntax>(new [] { CreateContractRequiresCall(node.Identifier.ToString()) }.Concat (bodyStatement.Statements)));
+
+                    var newRoot = (CompilationUnitSyntax) root.ReplaceNode((SyntaxNode)bodyStatement, newBody);
+
+                    if (UsingStatementNotPresent(newRoot)) newRoot = AddUsingStatement(node, newRoot);
+
+                    return Task.FromResult(document.WithSyntaxRoot(newRoot));
+                }
+            ) };
+        }
+
+        static ExpressionStatementSyntax CreateContractRequiresCall(string paramName)
+        {
+            var contract = SyntaxFactory.IdentifierName("Contract");
+            var requires = SyntaxFactory.IdentifierName("Requires");
+            var memberaccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, contract, requires);
+
+            var argument = SyntaxFactory.Argument(SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, SyntaxFactory.IdentifierName(paramName), SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
+            var argumentList = SyntaxFactory.SeparatedList(new[] { argument });
+
+            var contractRequiresCall =
+                SyntaxFactory.ExpressionStatement(
+                SyntaxFactory.InvocationExpression(memberaccess,
+                SyntaxFactory.ArgumentList(argumentList)));
+
+            return contractRequiresCall.WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+        }
+
+        static bool UsingStatementNotPresent(CompilationUnitSyntax cu)
+        {
+            return !cu.Usings.Any((UsingDirectiveSyntax u) => u.Name.ToString() == "System.Diagnostics.Contracts");
+        }
+
+        static CompilationUnitSyntax AddUsingStatement(ParameterSyntax node, CompilationUnitSyntax cu)
+        {
+            return cu.AddUsingDirective(
+                SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("System.Diagnostics.Contracts")).WithAdditionalAnnotations(Formatter.Annotation)
+                , node
+                , true);
+        }
+
+        static bool HasNotNullContract(SemanticModel semanticModel, IParameterSymbol parameterSymbol, BlockSyntax bodyStatement)
+        {
+            foreach (var expressions in bodyStatement.DescendantNodes().OfType<ExpressionStatementSyntax>())
+            {
+                var identifiers = expressions.DescendantNodes().OfType<IdentifierNameSyntax>();
+
+                if (Enumerable.SequenceEqual(identifiers.Select(i => i.Identifier.Text), new List<string>() { "Contract", "Requires", parameterSymbol.Name }))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/RefactoringEssentials/CodeRefactorings.CSharp.html
+++ b/RefactoringEssentials/CodeRefactorings.CSharp.html
@@ -15,7 +15,7 @@
 
     -->
     <h2>Supported Refactorings</h2>
-    <p>97 code refactorings for C#</p>
+    <p>98 code refactorings for C#</p>
     <ul>
       <li>Adds another accessor (AddAnotherAccessorCodeRefactoringProvider)</li>
       <li>Add braces (AddBracesCodeRefactoringProvider)</li>
@@ -31,6 +31,7 @@
       <li>Check StringBuilder index value (CheckStringBuilderIndexValueCodeRefactoringProvider)</li>
       <li>Check string index value (CheckStringIndexValueCodeRefactoringProvider)</li>
       <li>Compute constant value (ComputeConstantValueCodeRefactoringProvider)</li>
+      <li>Add a Contract to specify the paramter must not be null (ContractRequiresNotNullCodeRefactoringProvider)</li>
       <li>Convert anonymous method to lambda expression (ConvertAnonymousMethodToLambdaCodeRefactoringProvider)</li>
       <li>Convert auto-property to computed propertyy (ConvertAutoPropertyToPropertyCodeRefactoringProvider)</li>
       <li>Replace bitwise flag comparison with call to 'Enum.HasFlag' (ConvertBitwiseFlagComparisonToHasFlagsCodeRefactoringProvider)</li>

--- a/RefactoringEssentials/RefactoringEssentials.csproj
+++ b/RefactoringEssentials/RefactoringEssentials.csproj
@@ -42,6 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\NotPortedYetAttribute.cs" />
+    <Compile Include="CSharp\CodeRefactorings\Synced\ContractRequiresNotNullCodeRefactoringProvider.cs" />
     <Compile Include="CSharp\CodeRefactorings\Synced\MergeNestedIfAction.cs" />
     <Compile Include="CSharp\SyntaxExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/CSharp/CodeRefactorings/ContractRequiresNotNullTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ContractRequiresNotNullTests.cs
@@ -1,0 +1,187 @@
+using System;
+using NUnit.Framework;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using RefactoringEssentials.CSharp.CodeRefactorings;
+
+namespace RefactoringEssentials.Tests.CSharp.CodeRefactorings
+{
+    [TestFixture]
+    public class ContractRequiresNotNullTests : CSharpCodeRefactoringTestBase
+    {
+        [Test]
+        public void Test()
+        {
+            string result = RunContextAction(
+                                         new ContractRequiresNotNullCodeRefactoringProvider(),
+                                         "using System;" + Environment.NewLine +
+                                         "class TestClass" + Environment.NewLine +
+                                         "{" + Environment.NewLine +
+                                         "    void Test (string $param)" + Environment.NewLine +
+                                         "    {" + Environment.NewLine +
+                                         "        Console.WriteLine (param);" + Environment.NewLine +
+                                         "    }" + Environment.NewLine +
+                                         "}"
+                                     );
+
+            Assert.AreEqual(
+                "using System;" + Environment.NewLine +
+                "using System.Diagnostics.Contracts;" + Environment.NewLine + Environment.NewLine +
+            "class TestClass" + Environment.NewLine +
+                "{" + Environment.NewLine +
+                "    void Test (string param)" + Environment.NewLine +
+                "    {" + Environment.NewLine +
+                "        Contract.Requires(param != null);" + Environment.NewLine +
+                "        Console.WriteLine (param);" + Environment.NewLine +
+                "    }" + Environment.NewLine +
+                "}", result);
+        }
+
+        [Test]
+        public void TestLambda()
+        {
+            Test<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+    void Test ()
+    {
+        var lambda = ($sender, e) => {
+        };
+    }
+}", @"using System.Diagnostics.Contracts;
+
+class Foo
+{
+    void Test ()
+    {
+        var lambda = (sender, e) => {
+            Contract.Requires(sender != null);
+        };
+    }
+}");
+        }
+
+        [Test]
+        public void TestAnonymousMethod()
+        {
+            Test<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+    void Test ()
+    {
+        var lambda = delegate(object $-[sender]-, object e) {
+        };
+    }
+}", @"using System.Diagnostics.Contracts;
+
+class Foo
+{
+    void Test ()
+    {
+        var lambda = delegate(object sender, object e) {
+            Contract.Requires(sender != null);
+        };
+    }
+}");
+        }
+
+        [Test]
+        public void TestContractRequiresNotNullCheckAlreadyThere()
+        {
+            TestWrongContext<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+    void Test ()
+    {
+        var lambda = ($sender, e) => {
+            Contract.Requires(sender != null);
+        };
+    }
+}");
+        }
+
+        [Test]
+        public void TestContractRequiresNotNullCheckNotAlreadyThere()
+        {
+            Test<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+    void Test ()
+    {
+        var lambda = ($sender, e) => {
+            Contract.Requires(notSender != null);
+        };
+    }
+}", @"using System.Diagnostics.Contracts;
+
+class Foo
+{
+    void Test ()
+    {
+        var lambda = (sender, e) => {
+            Contract.Requires(sender != null);
+            Contract.Requires(notSender != null);
+        };
+    }
+}");
+        }
+
+        [Test]
+        public void TestUsingStatementAlreadyThere()
+        {
+            Test<ContractRequiresNotNullCodeRefactoringProvider>(@"using System.Diagnostics.Contracts;
+class Foo
+{
+    void Test ()
+    {
+        var lambda = ($sender, e) => {
+        };
+    }
+}", @"using System.Diagnostics.Contracts;
+class Foo
+{
+    void Test ()
+    {
+        var lambda = (sender, e) => {
+            Contract.Requires(sender != null);
+        };
+    }
+}");
+        }
+
+        [Test]
+        public void TestPopupOnlyOnName()
+        {
+            TestWrongContext<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+	void Test ($string param)
+	{
+	}
+}");
+        }
+
+
+        [Test]
+        public void Test_OldCSharp()
+        {
+            var parseOptions = new CSharpParseOptions(
+                LanguageVersion.CSharp5,
+                DocumentationMode.Diagnose | DocumentationMode.Parse,
+                SourceCodeKind.Regular,
+                ImmutableArray.Create("DEBUG", "TEST")
+            );
+
+            Test<ContractRequiresNotNullCodeRefactoringProvider>(@"class Foo
+{
+    void Test (string $test)
+    {
+    }
+}", @"using System.Diagnostics.Contracts;
+
+class Foo
+{
+    void Test (string test)
+    {
+        Contract.Requires(test != null);
+    }
+}", parseOptions: parseOptions);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="CSharp\CodeFixes\InvalidConversionTests.cs" />
     <Compile Include="CSharp\CodeFixes\ReturnMustNotBeFollowedByAnyExpressionCodeFixProviderTests.cs" />
     <Compile Include="CSharp\CodeFixes\UnreachableCodeTests.cs" />
+    <Compile Include="CSharp\CodeRefactorings\ContractRequiresNotNullTests.cs" />
     <Compile Include="CSharp\CodeRefactorings\GenerateSwitchLabelsTests.cs" />
     <Compile Include="CSharp\CodeRefactorings\ImportStaticClassWithUsingTests.cs" />
     <Compile Include="CSharp\CodeRefactorings\InitializeAutoPropertyFromConstructorParameterTests.cs" />


### PR DESCRIPTION
This adds a not null Contract (http://research.microsoft.com/en-us/projects/contracts/userdoc.pdf)
```Contract.Requires(paramName != null);```
As well as a using statement, if needed.
```using System.Diagnostics.Contracts;```