### PR TITLE
Fix Windows build.

### DIFF
--- a/RefactoringEssentials/RefactoringEssentials.csproj
+++ b/RefactoringEssentials/RefactoringEssentials.csproj
@@ -616,8 +616,8 @@
     <None Include="CodeAnalyzers.html.template" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0-beta1-20150812-01\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0-beta1-20150812-01\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />


### PR DESCRIPTION
The NuGet package was updated to Microsoft.CodeAnalysis.Analyzers
1.1.0 but the RefactoringEssentials project was still pointing
to 1.1.0-beta1 which causes the build to fail on Windows.