### PR TITLE
Add missing packages.config file.

### DIFF
--- a/RefactoringEssentials/packages.config
+++ b/RefactoringEssentials/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
+  <package id="Microsoft.DiaSymReader.Native" version="1.3.3" targetFramework="portable45-net45+win8" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
+</packages>


### PR DESCRIPTION
The RefactoringEssentials packages.config seems to have been deleted
in a merge from master. This causes a build error when doing a clean
build on Windows since the analzyer NuGet packages are not restored.