### PR TITLE
Allow methods returning null to be turned into expression bodied members

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertAutoPropertyToPropertyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertAutoPropertyToPropertyCodeRefactoringProvider.cs
@@ -35,6 +35,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
             if (property.AccessorList.Accessors.Any(b => b.Body != null)) //ignore properties with >=1 accessor body
                 return;
+
+            if (property.Parent is InterfaceDeclarationSyntax)
+                return;
+
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     property.Identifier.Span,

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
@@ -70,7 +70,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             var returnType = method.ReturnType as PredefinedTypeSyntax;
             if (returnType == null)
                 return;
-            BlockSyntax methodBody = returnType.Keyword.IsKind(SyntaxKind.VoidKeyword) ?
+            BlockSyntax methodBody = method.ReturnType.ToString().ToLower() == "void" ?
                 SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(expr)) :
                 SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr));
 

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
@@ -66,10 +66,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             ExpressionSyntax expr;
             if (!IsExpressionBody(method.Body, method.ExpressionBody, out expr))
                 return;
-            
-            var returnType = method.ReturnType as PredefinedTypeSyntax;
-            if (returnType == null)
-                return;
+                
             BlockSyntax methodBody = method.ReturnType.ToString().ToLower() == "void" ?
                 SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(expr)) :
                 SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr));

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
@@ -66,6 +66,14 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             ExpressionSyntax expr;
             if (!IsExpressionBody(method.Body, method.ExpressionBody, out expr))
                 return;
+            
+            var returnType = method.ReturnType as PredefinedTypeSyntax;
+            if (returnType == null)
+                return;
+            BlockSyntax methodBody = returnType.Keyword.IsKind(SyntaxKind.VoidKeyword) ?
+                SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(expr)) :
+                SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr));
+
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     token.Span,
@@ -76,7 +84,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                         var newRoot = root.ReplaceNode((SyntaxNode)
                             method,
                             method
-                            .WithBody(SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr)))
+                            .WithBody(methodBody)
                             .WithExpressionBody(null)
                             .WithSemicolonToken(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken))
                             .WithAdditionalAnnotations(Formatter.Annotation)

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertInstanceToStaticMethodCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertInstanceToStaticMethodCodeRefactoringProvider.cs
@@ -27,7 +27,7 @@ namespace RefactoringEssentials.CSharp
                 yield break;
 
             TypeDeclarationSyntax enclosingTypeDeclaration = methodDeclaration.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
-            if (enclosingTypeDeclaration == null)
+            if (enclosingTypeDeclaration == null || enclosingTypeDeclaration is InterfaceDeclarationSyntax)
                 yield break;
             if (methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
                 yield break;

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ReplaceAutoPropertyWithPropertyAndBackingFieldCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ReplaceAutoPropertyWithPropertyAndBackingFieldCodeRefactoringProvider.cs
@@ -34,6 +34,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
             if (property.AccessorList.Accessors.Any(b => !IsEmptyOrNotImplemented(b.Body))) //ignore properties with >=1 accessor body
                 return;
+
+            if (property.Parent is InterfaceDeclarationSyntax)
+                return;
+
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     property.Identifier.Span,

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ToAbstractVirtualNonVirtualConversionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ToAbstractVirtualNonVirtualConversionCodeRefactoringProvider.cs
@@ -50,7 +50,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                 return;
 
             var declarationParent = declaration.Parent as TypeDeclarationSyntax;
-            if (declarationParent == null)
+            if (declarationParent == null || declarationParent is InterfaceDeclarationSyntax)
                 return;
 
             var explicitInterface = declaration.GetExplicitInterfaceSpecifierSyntax();

--- a/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
@@ -43,6 +43,25 @@ class TestClass
     }
 }");
         }
+
+        [Test]
+        public void TestVoidMethod()
+        {
+            Test<ConvertExpressionBodyToStatementBodyCodeRefactoringProvider>(@"
+class TestClass
+{
+    void Foo();
+    void $TestMethod() => Foo();
+}", @"
+class TestClass
+{
+    void Foo();
+    void TestMethod()
+    {
+        Foo();
+    }
+}");
+        }
     }
 }
 


### PR DESCRIPTION
Hi
This pr fixes issue #271.

I have changed **ConvertExpressionBodyToStatementBodyCodeRefactoringProvider** so it will properly handle a case where expression was a void type and still was converting to a ReturnStatement.

I have also added a corresponding unit test that handle this case.