### PR TITLE
Fixed void expression-bodied method was expanding into ReturnStatement method body

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
@@ -85,7 +85,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                         var newRoot = root.ReplaceNode((SyntaxNode)
                             method,
                             method
-                            .WithBody(SyntaxFactory.Block(methodBody))
+                            .WithBody(methodBody)
                             .WithExpressionBody(null)
                             .WithSemicolonToken(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken))
                             .WithAdditionalAnnotations(Formatter.Annotation)

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertExpressionBodyToStatementBodyCodeRefactoringProvider.cs
@@ -33,7 +33,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             var token = root.FindToken(span.Start);
             var method = GetDeclaration<MethodDeclarationSyntax>(token);
             if (method != null)
-                HandleMethodCase(context, root, token, method);
+                HandleMethodCase(context, model, root, token, method);
 
             var property = GetDeclaration<PropertyDeclarationSyntax>(token);
             if (property != null)
@@ -61,11 +61,20 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             return null;
         }
 
-        static void HandleMethodCase(CodeRefactoringContext context, SyntaxNode root, SyntaxToken token, MethodDeclarationSyntax method)
+        static void HandleMethodCase(CodeRefactoringContext context, SemanticModel model, SyntaxNode root, SyntaxToken token, MethodDeclarationSyntax method)
         {
             ExpressionSyntax expr;
             if (!IsExpressionBody(method.Body, method.ExpressionBody, out expr))
                 return;
+
+            var methodSymbol = model.GetDeclaredSymbol(method);
+            if (methodSymbol == null)
+                return;
+            
+            BlockSyntax methodBody =  methodSymbol.ReturnsVoid ?
+                SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(expr)) :
+                SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr));
+
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     token.Span,
@@ -76,7 +85,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                         var newRoot = root.ReplaceNode((SyntaxNode)
                             method,
                             method
-                            .WithBody(SyntaxFactory.Block(SyntaxFactory.ReturnStatement(expr)))
+                            .WithBody(SyntaxFactory.Block(methodBody))
                             .WithExpressionBody(null)
                             .WithSemicolonToken(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken))
                             .WithAdditionalAnnotations(Formatter.Annotation)

--- a/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
@@ -43,7 +43,7 @@ class TestClass
 }");
         }
 
-        [Test]
+        [Fact]
         public void TestVoidMethod()
         {
             Test<ConvertExpressionBodyToStatementBodyCodeRefactoringProvider>(@"

--- a/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ConvertExpressionBodyToStatementBodyTests.cs
@@ -42,6 +42,25 @@ class TestClass
     }
 }");
         }
+
+        [Test]
+        public void TestVoidMethod()
+        {
+            Test<ConvertExpressionBodyToStatementBodyCodeRefactoringProvider>(@"
+class TestClass
+{
+    void Foo();
+    void $TestMethod() => Foo();
+}", @"
+class TestClass
+{
+    void Foo();
+    void TestMethod()
+    {
+        Foo();
+    }
+}");
+        }
     }
 }
 


### PR DESCRIPTION
Hi
This pr fixes issue #271.

I have changed ConvertExpressionBodyToStatementBodyCodeRefactoringProvider so it will properly handle a case where expression was a void type and still was converting to a ReturnStatement.

I have also added a corresponding unit test that handle this case.