### PR TITLE
Fixed some refactoring providers that could cause converting interface members into non-abstract ones

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertAutoPropertyToPropertyCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertAutoPropertyToPropertyCodeRefactoringProvider.cs
@@ -35,6 +35,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
             if (property.AccessorList.Accessors.Any(b => b.Body != null)) //ignore properties with >=1 accessor body
                 return;
+
+            TypeDeclarationSyntax enclosingTypeDeclaration = property.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if(enclosingTypeDeclaration == null || enclosingTypeDeclaration is InterfaceDeclarationSyntax)
+                return;
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     property.Identifier.Span,

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertInstanceToStaticMethodCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ConvertInstanceToStaticMethodCodeRefactoringProvider.cs
@@ -26,7 +26,7 @@ namespace RefactoringEssentials.CSharp
                 yield break;
 
             TypeDeclarationSyntax enclosingTypeDeclaration = methodDeclaration.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
-            if (enclosingTypeDeclaration == null)
+            if (enclosingTypeDeclaration == null || enclosingTypeDeclaration is InterfaceDeclarationSyntax)
                 yield break;
             if (methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
                 yield break;

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ReplaceAutoPropertyWithPropertyAndBackingFieldCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ReplaceAutoPropertyWithPropertyAndBackingFieldCodeRefactoringProvider.cs
@@ -34,6 +34,10 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
 
             if (property.AccessorList.Accessors.Any(b => !IsEmptyOrNotImplemented(b.Body))) //ignore properties with >=1 accessor body
                 return;
+            
+            TypeDeclarationSyntax enclosingTypeDeclaration = property.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if(enclosingTypeDeclaration == null || enclosingTypeDeclaration is InterfaceDeclarationSyntax)
+                return;
             context.RegisterRefactoring(
                 CodeActionFactory.Create(
                     property.Identifier.Span,

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ToAbstractVirtualNonVirtualConversionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Synced/ToAbstractVirtualNonVirtualConversionCodeRefactoringProvider.cs
@@ -49,8 +49,8 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             if (modifiers.Any(m => m.IsKind(SyntaxKind.OverrideKeyword)))
                 return;
 
-            var declarationParent = declaration.Parent as TypeDeclarationSyntax;
-            if (declarationParent == null)
+            TypeDeclarationSyntax enclosingTypeDeclaration = declaration.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+            if (enclosingTypeDeclaration == null || enclosingTypeDeclaration is InterfaceDeclarationSyntax)
                 return;
 
             var explicitInterface = declaration.GetExplicitInterfaceSpecifierSyntax();
@@ -73,7 +73,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             //			if (!node.GetChildByRole(EntityDeclaration.PrivateImplementationTypeRole).IsNull)
             //				yield break;
             //
-            if (declarationParent.Modifiers.Any(m => m.IsKind(SyntaxKind.AbstractKeyword)))
+            if (enclosingTypeDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.AbstractKeyword)))
             {
                 if (modifiers.Any(m => m.IsKind(SyntaxKind.AbstractKeyword)))
                 {
@@ -138,7 +138,7 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                     )
                     );
                 }
-                else if (!declarationParent.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
+                else if (!enclosingTypeDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
                 {
                     context.RegisterRefactoring(CodeActionFactory.Create(
                         token.Span,


### PR DESCRIPTION
This pr fixes issue #262, so its not possible anymore to:
- Replace auto-property with property that uses a backing field
- Convert auto-property to computed property
- Make abstract member virtual
- Convert instance to static method