### PR TITLE
Fixed PutInsideUsingAction bug with impicitly typed variables

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
@@ -150,9 +150,14 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                     insideUsing.Insert(i + 1, needAssignment.Declarator.InitializerAsAssignment());
                 }
 
+                var typeSyntax = localDeclarationStmt.Declaration.Type;
+                var type = semanticModel.GetSymbolInfo(typeSyntax).Symbol;
+
                 beforeUsing.Add(SyntaxFactory.LocalDeclarationStatement(
                         SyntaxFactory.VariableDeclaration(
-                            localDeclarationStmt.Declaration.Type,
+                            SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(semanticModel, typeSyntax.SpanStart))
+                                .WithLeadingTrivia(typeSyntax.GetLeadingTrivia())
+                                .WithTrailingTrivia(typeSyntax.GetTrailingTrivia()),
                             SyntaxFactory.SeparatedList(variablesToMove.Select(x => x.Declarator.WithInitializer(null)))
                             )
                     )

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/PutInsideUsingAction.cs
@@ -150,14 +150,22 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                     insideUsing.Insert(i + 1, needAssignment.Declarator.InitializerAsAssignment());
                 }
 
-                var typeSyntax = localDeclarationStmt.Declaration.Type;
-                var type = semanticModel.GetSymbolInfo(typeSyntax).Symbol;
+                var localDeclarationTypeSyntax = localDeclarationStmt.Declaration.Type;
+
+                if(localDeclarationTypeSyntax.IsVar)
+                {
+                    var localDeclarationTypeSymbol = semanticModel.GetSymbolInfo(localDeclarationTypeSyntax).Symbol;
+
+                    var localDeclarationTypeName = localDeclarationTypeSymbol.ToMinimalDisplayString(semanticModel, localDeclarationTypeSyntax.SpanStart);
+
+                    localDeclarationTypeSyntax = SyntaxFactory.ParseTypeName(localDeclarationTypeName)
+                        .WithLeadingTrivia(localDeclarationTypeSyntax.GetLeadingTrivia())
+                        .WithTrailingTrivia(localDeclarationTypeSyntax.GetTrailingTrivia());
+                }
 
                 beforeUsing.Add(SyntaxFactory.LocalDeclarationStatement(
                         SyntaxFactory.VariableDeclaration(
-                            SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(semanticModel, typeSyntax.SpanStart))
-                                .WithLeadingTrivia(typeSyntax.GetLeadingTrivia())
-                                .WithTrailingTrivia(typeSyntax.GetTrailingTrivia()),
+                            localDeclarationTypeSyntax,
                             SyntaxFactory.SeparatedList(variablesToMove.Select(x => x.Declarator.WithInitializer(null)))
                             )
                     )

--- a/Tests/CSharp/CodeRefactorings/PutInsideUsingTests.cs
+++ b/Tests/CSharp/CodeRefactorings/PutInsideUsingTests.cs
@@ -392,6 +392,34 @@ class TestClass
     }
 }");
         }
+
+        [Fact]
+        public void TestChangeVarDeclarationToExplicit()
+        {
+            Test<PutInsideUsingAction>(@"
+class TestClass
+{
+    void TestMethod ()
+    {
+        System.IDisposable obj $= null;
+        var a = obj.GetHashCode();        
+        return a;
+    }
+}", @"
+class TestClass
+{
+    void TestMethod ()
+    {
+        int a;
+        using (System.IDisposable obj = null)
+        {
+            a = obj.GetHashCode();
+        }
+
+        return a;
+    }
+}");
+        }
     }
 
    


### PR DESCRIPTION
This pr fixes issue #281 when implicitly typed declarations became `var <variableName>;` instead of explicit type resolving.
I have also added a unit test for handling this case.