### PR TITLE
Reimplemented ChangeAccessModifierAction

### DIFF
--- a/RefactoringEssentials.2017/CodeRefactorings.CSharp.html
+++ b/RefactoringEssentials.2017/CodeRefactorings.CSharp.html
@@ -15,7 +15,7 @@
 
     -->
     <h2>Supported Refactorings</h2>
-    <p>103 code refactorings for C#</p>
+    <p>104 code refactorings for C#</p>
     <ul>
       <li>Adds another accessor (AddAnotherAccessorCodeRefactoringProvider)</li>
       <li>Add braces (AddBracesCodeRefactoringProvider)</li>
@@ -25,6 +25,7 @@
       <li>Introduce format item (AddNewFormatItemCodeRefactoringProvider)</li>
       <li>Add null check (AddNullCheckCodeRefactoringProvider)</li>
       <li>Add one or more optional parameters to an invocation, using their default values (AddOptionalParameterToInvocationCodeRefactoringProvider)</li>
+      <li>Changes the access level of an entity declaration (ChangeAccessModifierAction)</li>
       <li>Check array index value (CheckArrayIndexValueCodeRefactoringProvider)</li>
       <li>Check collection index value (CheckCollectionIndexValueCodeRefactoringProvider)</li>
       <li>Check dictionary key value (CheckDictionaryKeyValueCodeRefactoringProvider)</li>

--- a/RefactoringEssentials.2017/missing.md
+++ b/RefactoringEssentials.2017/missing.md
@@ -6,7 +6,6 @@
 **C#**
 
 * AutoLinqSumAction
-* ChangeAccessModifierAction
 * CreateIndexerAction
 * GenerateGetterAction
 * IntroduceConstantAction

--- a/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/ChangeAccessModifierAction.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Uncategorized/ChangeAccessModifierAction.cs
@@ -41,21 +41,21 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
                 return;
             
             ISymbol symbol = null;
-            switch(node)
+            var field = node as FieldDeclarationSyntax;
+            if(field != null)
+                symbol = model.GetDeclaredSymbol(field.Declaration.Variables.First(), cancellationToken);
+            else
             {
-                case FieldDeclarationSyntax field:
-                    symbol = model.GetDeclaredSymbol(field.Declaration.Variables.First(), cancellationToken);
-                    break;
-
-                case MemberDeclarationSyntax member:
+                var member = node as MemberDeclarationSyntax;
+                if(member != null)
                     symbol = model.GetDeclaredSymbol(member, cancellationToken);
-                    break;
-
-                case AccessorDeclarationSyntax accessor:
-                    symbol = model.GetDeclaredSymbol(accessor, cancellationToken);
-                    break;
+                else
+                {
+                    var accessor = node as AccessorDeclarationSyntax;
+                    if(accessor != null)
+                        symbol = model.GetDeclaredSymbol(accessor, cancellationToken);
+                }
             }
-
             if (!symbol.AccessibilityChangeable())
                 return;
             

--- a/RefactoringEssentials/Util/CommonAccessibilityUtilities.cs
+++ b/RefactoringEssentials/Util/CommonAccessibilityUtilities.cs
@@ -36,6 +36,39 @@ namespace RefactoringEssentials
 
             return Accessibility.Public;
         }
+
+        public static bool AccessibilityChangeable(this ISymbol member)
+        {
+            if (member == null ||
+                member.IsOverride ||
+                member.IsUserDefinedOperator() ||
+                member.IsDestructor() ||
+                member.IsEventAccessor() ||
+                (member.ContainingType?.IsInterfaceType() ?? false) ||
+                member.ExplicitInterfaceImplementations().Length > 0 ||
+                IsInterfaceImplementation(member))
+                return false;
+            return true;
+        }
+
+        static bool IsInterfaceImplementation(ISymbol member)
+        {
+            var containingType = member.ContainingType;
+            if (containingType == null)
+                return false;
+
+            foreach (var iface in containingType.AllInterfaces)
+            {
+                foreach (var imember in iface.GetMembers())
+                {
+                    var implementation = containingType.FindImplementationForInterfaceMember(imember);
+                    if (implementation == member)
+                        return true;
+                }
+            }
+
+            return false;
+        }
     }
 
 }

--- a/RefactoringEssentials/Util/SyntaxTokenExtensions.cs
+++ b/RefactoringEssentials/Util/SyntaxTokenExtensions.cs
@@ -1131,5 +1131,24 @@ namespace RefactoringEssentials
             }
         }
 
+        public static bool IsIdentifierOrAccessorOrAccessibilityModifier(this SyntaxToken token)
+        {
+            switch (token.Kind())
+            {
+                case SyntaxKind.IdentifierName:
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.GetKeyword:
+                case SyntaxKind.SetKeyword:
+                case SyntaxKind.PrivateKeyword:
+                case SyntaxKind.ProtectedKeyword:
+                case SyntaxKind.InternalKeyword:
+                case SyntaxKind.PublicKeyword:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
     }
 }

--- a/Tests/CSharp/CodeRefactorings/ChangeAccessModifierTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ChangeAccessModifierTests.cs
@@ -26,6 +26,18 @@ interface Test
         }
 
         [Fact]
+        public void TestType()
+        {
+            Test<ChangeAccessModifierAction>(@"
+class $Foo
+{
+}", @"
+public class Foo
+{
+}");
+        }
+
+        [Fact]
         public void TestNoExplicitInterfaceImplementationMember()
         {
             TestWrongContext<ChangeAccessModifierAction>(@"
@@ -53,19 +65,7 @@ class TestClass : Test
 }");
         }
 
-        [Fact(Skip="Not implemented!")]
-        public void TestType()
-        {
-            Test<ChangeAccessModifierAction>(@"
-class $Foo
-{
-}", @"
-public class Foo
-{
-}");
-        }
-
-        [Fact(Skip="Not implemented!")]
+        [Fact]
         public void TestMethodToProtected()
         {
             Test<ChangeAccessModifierAction>(@"
@@ -83,7 +83,7 @@ class Foo
 }");
         }
 
-        [Fact(Skip="Not implemented!")]
+        [Fact]
         public void TestPrivateMethodToProtected()
         {
             Test<ChangeAccessModifierAction>(@"
@@ -101,7 +101,7 @@ class Foo
 }");
         }
 
-        [Fact(Skip="Not implemented!")]
+        [Fact]
         public void TestMethodToProtectedInternal()
         {
             Test<ChangeAccessModifierAction>(@"
@@ -116,10 +116,10 @@ class Foo
 	protected internal void Bar ()
 	{
 	}
-}", 1);
+}", 2);
         }
 
-        [Fact(Skip="Not implemented!")]
+        [Fact]
         public void TestAccessor()
         {
             Test<ChangeAccessModifierAction>(@"
@@ -152,7 +152,7 @@ class Foo
 }");
         }
 
-        [Fact(Skip="Not implemented!")]
+        [Fact]
         public void TestChangeAccessor()
         {
             Test<ChangeAccessModifierAction>(@"
@@ -205,7 +205,22 @@ class BaseClass : IDisposable
 }");
         }
 
+        [Fact]
+        public void TestChangeField()
+        {
+            Test<ChangeAccessModifierAction>(@"
+class Foo
+{
+	$public int f;
+}", @"
+class Foo
+{
+	private int f;
+}");
+        }
 
     }
+
+        
 }
 


### PR DESCRIPTION
This pull request is about porting refactoring provider for changing access modifier (ChangeAccessModifierAction).

I have written a couple of methods that are related to directly to accessibility level and should be in an independent utility class (GetPossibleAccessibilities and GetAccessibilityModifiers methods) like CSharpAccessibilityUtilities, but i'm not sure maybe i could just place them in CommonAccessibilityUtilities or CSharpUtilities classes. It is also questionable if AccessibilityChangeable extension method could be placed in CommonAccessibilityUtilities class due to it was actually implemented according to C# language specification.

All related unit tests are passing including a new one introduced for checking fields access modifier changing.