### PR TITLE
[Performance] Delay grabbing all declared symbols until actually needed

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
@@ -44,7 +44,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                 return;
             if (memberSymbol is IMethodSymbol && ((IMethodSymbol)memberSymbol).MethodKind == MethodKind.Constructor || memberSymbol.ExplicitInterfaceImplementations().Length > 0)
                 return;
-            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart);
+            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart, memberSymbol.ContainingType);
             foreach (var param in node.Parameters)
             {
                 var hidingMember = symbols.FirstOrDefault(v => v.Name == param.Identifier.ValueText && ((memberSymbol.IsStatic && v.IsStatic) || !memberSymbol.IsStatic) && !v.IsKind(SymbolKind.Local) && !v.IsKind(SymbolKind.Parameter));

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
@@ -44,7 +44,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                 return;
             if (memberSymbol is IMethodSymbol && ((IMethodSymbol)memberSymbol).MethodKind == MethodKind.Constructor || memberSymbol.ExplicitInterfaceImplementations().Length > 0)
                 return;
-            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart, memberSymbol.ContainingType);
+            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart, memberSymbol.GetContainingTypeOrThis());
             foreach (var param in node.Parameters)
             {
                 var hidingMember = symbols.FirstOrDefault(v => v.Name == param.Identifier.ValueText && ((memberSymbol.IsStatic && v.IsStatic) || !memberSymbol.IsStatic) && !v.IsKind(SymbolKind.Local) && !v.IsKind(SymbolKind.Parameter));

--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/CodeQuality/ParameterHidesMemberAnalyzer.cs
@@ -37,7 +37,6 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             if (member == null)
                 return;
 
-            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart);
             var memberSymbol = nodeContext.SemanticModel.GetDeclaredSymbol(member);
             if (memberSymbol == null)
                 return;
@@ -45,6 +44,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                 return;
             if (memberSymbol is IMethodSymbol && ((IMethodSymbol)memberSymbol).MethodKind == MethodKind.Constructor || memberSymbol.ExplicitInterfaceImplementations().Length > 0)
                 return;
+            var symbols = nodeContext.SemanticModel.LookupSymbols(node.SpanStart);
             foreach (var param in node.Parameters)
             {
                 var hidingMember = symbols.FirstOrDefault(v => v.Name == param.Identifier.ValueText && ((memberSymbol.IsStatic && v.IsStatic) || !memberSymbol.IsStatic) && !v.IsKind(SymbolKind.Local) && !v.IsKind(SymbolKind.Parameter));


### PR DESCRIPTION
From my profiling of Expression.cs on the mcs project, there were 625 calls to AnalyzeParameterList, but only 47 calls to the `FirstOrDefault` inside the inner loop.

That means we're unnecessarily querying the symbols for the given span.