### PR TITLE
Fix spurious 0154 diagnostics

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInDeclaration/UnusedParameterAnalyzer.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/RedundanciesInDeclaration/UnusedParameterAnalyzer.cs
@@ -188,7 +188,7 @@ namespace RefactoringEssentials.CSharp.Diagnostics
                 if (node.ParameterList.Parameters.Count == 0)
                     return;
 
-                Analyze(node.ParameterList.Parameters, new SyntaxNode[] { node.Body, node.Initializer }, node.Kind());
+                Analyze(node.ParameterList.Parameters, new SyntaxNode[] { node.Body, node.ExpressionBody, node.Initializer }, node.Kind());
             }
 
             public override void VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)

--- a/Tests/CSharp/Diagnostics/UnusedParameterTests.cs
+++ b/Tests/CSharp/Diagnostics/UnusedParameterTests.cs
@@ -282,5 +282,25 @@ class TestClass {
 }";
             Analyze<UnusedParameterAnalyzer>(input);
         }
+
+        [Fact]
+        public void UnusedParameterInExpressionBodiedConstructor()
+        {
+            var input = @"
+class TestClass {
+    public TestClass(int $i$) => "";
+}";
+            Analyze<UnusedParameterAnalyzer>(input);
+        }
+
+        [Fact]
+        public void UsedParameterInExpressionBodiedConstructor()
+        {
+            var input = @"
+class TestClass {
+    public TestClass(int i) => i.ToString();
+}";
+            Analyze<UnusedParameterAnalyzer>(input);
+        }
     }
 }


### PR DESCRIPTION
The unused parameter analyzer now recognizes expression bodied constructors.

Resolves #320