### PR TITLE
Better Visual Basic to C Sharp conversion

### DIFF
--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -33,7 +33,10 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node)
 			{
-				return SingleStatement(SyntaxFactory.ParseStatement("System.Environment.Exit(0);"));
+				var cSharpEquivalent = node.StopOrEndKeyword.IsKind(VBasic.SyntaxKind.StopKeyword) ? "System.Diagnostics.Debugger.Break();"
+					: node.StopOrEndKeyword.IsKind(VBasic.SyntaxKind.EndKeyword) ? "System.Environment.Exit(0);"
+						: throw new NotImplementedException(node.StopOrEndKeyword.Kind() + " not implemented!");
+				return SingleStatement(SyntaxFactory.ParseStatement(cSharpEquivalent));
 			}
 
 			public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -30,6 +30,11 @@ namespace RefactoringEssentials.CSharp.Converter
 				throw new NotImplementedException(node.GetType() + " not implemented!");
 			}
 
+			public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node)
+			{
+				return SingleStatement(SyntaxFactory.ParseStatement("System.Environment.Exit(-1);"));
+			}
+
 			public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)
 			{
 				var modifiers = ConvertModifiers(node.Modifiers, TokenContext.Local);

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -285,7 +285,7 @@ namespace RefactoringEssentials.CSharp.Converter
 							labels.Add(SyntaxFactory.DefaultSwitchLabel());
 						} else return false;
 					}
-					var list = SyntaxFactory.List(block.Statements.SelectMany(s => s.Accept(this)).Concat(SyntaxFactory.BreakStatement()));
+					var list = SingleStatement(SyntaxFactory.Block(block.Statements.SelectMany(s => s.Accept(this)).Concat(SyntaxFactory.BreakStatement())));
 					sections.Add(SyntaxFactory.SwitchSection(SyntaxFactory.List(labels), list));
 				}
 				switchStatement = SyntaxFactory.SwitchStatement(expr, SyntaxFactory.List(sections));

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -33,7 +33,7 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node)
 			{
-				return SingleStatement(SyntaxFactory.ParseStatement("System.Environment.Exit(-1);"));
+				return SingleStatement(SyntaxFactory.ParseStatement("System.Environment.Exit(0);"));
 			}
 
 			public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -34,10 +34,20 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node)
 			{
-				var cSharpEquivalent = node.StopOrEndKeyword.IsKind(VBasic.SyntaxKind.StopKeyword) ? "System.Diagnostics.Debugger.Break();"
-					: node.StopOrEndKeyword.IsKind(VBasic.SyntaxKind.EndKeyword) ? "System.Environment.Exit(0);"
-						: throw new NotImplementedException(node.StopOrEndKeyword.Kind() + " not implemented!");
-				return SingleStatement(SyntaxFactory.ParseStatement(cSharpEquivalent));
+				return SingleStatement(SyntaxFactory.ParseStatement(GetCSharpEquivalentStatementText(node)));
+			}
+
+			private static string GetCSharpEquivalentStatementText(VBSyntax.StopOrEndStatementSyntax node)
+			{
+				switch (VBasic.VisualBasicExtensions.Kind(node.StopOrEndKeyword))
+				{
+					case VBasic.SyntaxKind.StopKeyword:
+						return "System.Diagnostics.Debugger.Break();";
+					case VBasic.SyntaxKind.EndKeyword:
+						return "System.Environment.Exit(0);";
+					default:
+						throw new NotImplementedException(node.StopOrEndKeyword.Kind() + " not implemented!");
+				}
 			}
 
 			public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -43,6 +43,14 @@ namespace RefactoringEssentials.CSharp.Converter
 				return SyntaxFactory.List<StatementSyntax>(declarations);
 			}
 
+			public override SyntaxList<StatementSyntax> VisitAddRemoveHandlerStatement(VBSyntax.AddRemoveHandlerStatementSyntax node)
+			{
+				var syntaxKind = node.Kind() == VBasic.SyntaxKind.AddHandlerStatement ? SyntaxKind.AddAssignmentExpression : SyntaxKind.SubtractAssignmentExpression;
+				return SingleStatement(SyntaxFactory.AssignmentExpression(syntaxKind,
+					(ExpressionSyntax) node.EventExpression.Accept(nodesVisitor),
+					(ExpressionSyntax) node.DelegateExpression.Accept(nodesVisitor)));
+			}
+
 			public override SyntaxList<StatementSyntax> VisitExpressionStatement(VBSyntax.ExpressionStatementSyntax node)
 			{
 				return SingleStatement((ExpressionSyntax)node.Expression.Accept(nodesVisitor));

--- a/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/MethodBodyVisitor.cs
@@ -263,7 +263,7 @@ namespace RefactoringEssentials.CSharp.Converter
 			public override SyntaxList<StatementSyntax> VisitWithBlock(VBSyntax.WithBlockSyntax node)
 			{
 				var withExpression = (ExpressionSyntax) node.WithStatement.Expression.Accept(nodesVisitor);
-				withBlockTempVariableNames.Push("withBlock");
+				withBlockTempVariableNames.Push(GetUniqueVariableNameInScope(node, "withBlock"));
 				try
 				{
 					var variableDeclaratorSyntax = SyntaxFactory.VariableDeclarator(
@@ -281,7 +281,14 @@ namespace RefactoringEssentials.CSharp.Converter
 					withBlockTempVariableNames.Pop();
 				}
 			}
-			
+
+			private string GetUniqueVariableNameInScope(SyntaxNode node, string variableNameBase)
+			{
+				var reservedNames = withBlockTempVariableNames.Concat(node.DescendantNodesAndSelf()
+					.SelectMany(syntaxNode => semanticModel.LookupSymbols(syntaxNode.SpanStart).Select(s => s.Name)));
+				return NameGenerator.EnsureUniqueness(variableNameBase, reservedNames, true);
+			}
+
 			private bool ConvertToSwitch(ExpressionSyntax expr, SyntaxList<VBSyntax.CaseBlockSyntax> caseBlocks, out SwitchStatementSyntax switchStatement)
 			{
 				switchStatement = null;

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -819,10 +819,18 @@ namespace RefactoringEssentials.CSharp.Converter
 			{
 				var simpleNameSyntax = (SimpleNameSyntax)node.Name.Accept(this);
 
-				var left = (ExpressionSyntax)node.Expression?.Accept(this);
+				var left = (ExpressionSyntax) node.Expression?.Accept(this);
 				if (left == null)
-					return SyntaxFactory.MemberBindingExpression(simpleNameSyntax);
-				else if (node.Expression.IsKind(VBasic.SyntaxKind.GlobalName))
+				{
+					if (!node.Parent.Parent.IsKind(VBasic.SyntaxKind.WithBlock))
+					{
+						return SyntaxFactory.MemberBindingExpression(simpleNameSyntax);
+					}
+
+					left = SyntaxFactory.IdentifierName(MethodBodyVisitor.WithBlockTempVariableName);
+				}
+
+				if (node.Expression.IsKind(VBasic.SyntaxKind.GlobalName))
 				{
 					return SyntaxFactory.AliasQualifiedName((IdentifierNameSyntax) left, simpleNameSyntax);
 				}

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -885,9 +885,10 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override CSharpSyntaxNode VisitObjectCreationExpression(VBSyntax.ObjectCreationExpressionSyntax node)
 			{
+				var argumentListSyntax = node.ArgumentList ?? VBasic.SyntaxFactory.ArgumentList(); //VB can omit empty arg lists entirely
 				return SyntaxFactory.ObjectCreationExpression(
 					(TypeSyntax)node.Type.Accept(this),
-					(ArgumentListSyntax)node.ArgumentList?.Accept(this),
+					(ArgumentListSyntax)argumentListSyntax.Accept(this),
 					(InitializerExpressionSyntax)node.Initializer?.Accept(this)
 				);
 			}

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -916,7 +916,7 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override CSharpSyntaxNode VisitObjectCollectionInitializer(VBSyntax.ObjectCollectionInitializerSyntax node)
 			{
-				return SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression, SyntaxFactory.SingletonSeparatedList((ExpressionSyntax) node.Initializer.Accept(this)));
+				return node.Initializer.Accept(this); //Dictionary initializer comes through here despite the FROM keyword not being in the source code
 			}
 
 			ExpressionSyntax IncreaseArrayUpperBoundExpression(VBSyntax.ExpressionSyntax expr)

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -879,6 +879,11 @@ namespace RefactoringEssentials.CSharp.Converter
 				return SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression, SyntaxFactory.SeparatedList(node.Initializers.Select(i => (ExpressionSyntax)i.Accept(this))));
 			}
 
+			public override CSharpSyntaxNode VisitObjectCollectionInitializer(VBSyntax.ObjectCollectionInitializerSyntax node)
+			{
+				return SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression, SyntaxFactory.SingletonSeparatedList((ExpressionSyntax) node.Initializer.Accept(this)));
+			}
+
 			ExpressionSyntax IncreaseArrayUpperBoundExpression(VBSyntax.ExpressionSyntax expr)
 			{
 				var constant = semanticModel.GetConstantValue(expr);

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -29,6 +29,11 @@ namespace RefactoringEssentials.CSharp.Converter
 				throw new NotImplementedException(node.GetType() + " not implemented!");
 			}
 
+			public override CSharpSyntaxNode VisitGetTypeExpression(VBSyntax.GetTypeExpressionSyntax node)
+			{
+				return SyntaxFactory.TypeOfExpression((TypeSyntax) node.Type.Accept(this));
+			}
+
 			public override CSharpSyntaxNode VisitGlobalName(VBSyntax.GlobalNameSyntax node)
 			{
 				return SyntaxFactory.IdentifierName(SyntaxFactory.Token(SyntaxKind.GlobalKeyword));

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -860,7 +860,7 @@ namespace RefactoringEssentials.CSharp.Converter
 				if (symbol != null)
 				{
 					var parameterKinds = symbol.GetParameters().Select(param => param.RefKind).ToList();
-
+					//WARNING: If named parameters can reach here it won't work properly for them
 					var refKind = argID >= parameterKinds.Count && symbol.IsParams() ? RefKind.None : parameterKinds[argID];
 					switch (refKind)
 					{

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -16,14 +16,12 @@ namespace RefactoringEssentials.CSharp.Converter
 		{
 			SemanticModel semanticModel;
 			Document targetDocument;
-			CSharpCompilationOptions options;
 			readonly Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax[]> additionalDeclarations = new Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax[]>();
 
 			public NodesVisitor(SemanticModel semanticModel, Document targetDocument)
 			{
 				this.semanticModel = semanticModel;
 				this.targetDocument = targetDocument;
-				this.options = (CSharpCompilationOptions)targetDocument?.Project.CompilationOptions;
 			}
 
 			public override CSharpSyntaxNode DefaultVisit(SyntaxNode node)

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -1014,6 +1014,10 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override CSharpSyntaxNode VisitPredefinedType(VBSyntax.PredefinedTypeSyntax node)
 			{
+				if (node.Keyword.IsKind(VBasic.SyntaxKind.DateKeyword))
+				{
+					return SyntaxFactory.IdentifierName("System.DateTime");
+				}
 				return SyntaxFactory.PredefinedType(ConvertToken(node.Keyword));
 			}
 

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -785,10 +785,10 @@ namespace RefactoringEssentials.CSharp.Converter
 				SyntaxToken token = default(SyntaxToken);
 				if (symbol != null)
 				{
-					var parameterSymbols = symbol.GetParameters();
+					var parameterKinds = symbol.GetParameters().Select(param => param.RefKind).ToList();
 
-					var p = parameterSymbols[argID];
-					switch (p.RefKind)
+					var refKind = argID >= parameterKinds.Count && symbol.IsParams() ? RefKind.None : parameterKinds[argID];
+					switch (refKind)
 					{
 						case RefKind.None:
 							token = default(SyntaxToken);

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -770,7 +770,9 @@ namespace RefactoringEssentials.CSharp.Converter
 				SyntaxToken token = default(SyntaxToken);
 				if (symbol != null)
 				{
-                    var p = symbol.GetParameters()[argID];
+					var parameterSymbols = symbol.GetParameters();
+
+					var p = parameterSymbols[argID];
 					switch (p.RefKind)
 					{
 						case RefKind.None:

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -1000,14 +1000,15 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override CSharpSyntaxNode VisitInvocationExpression(VBSyntax.InvocationExpressionSyntax node)
 			{
-				var invocationSymbol = semanticModel.GetSymbolInfo(node).Symbol;
-				var symbol = semanticModel.GetSymbolInfo(node.Expression).Symbol;
-				if (invocationSymbol?.IsIndexer() == true || symbol?.GetReturnType()?.IsArrayType() == true)
+				var invocationSymbol = ExtractMatch(semanticModel.GetSymbolInfo(node));
+				var symbol = ExtractMatch(semanticModel.GetSymbolInfo(node.Expression));
+				if (invocationSymbol?.IsIndexer() == true || symbol?.GetReturnType()?.IsArrayType() == true && !(symbol is IMethodSymbol)) //The null case happens quite a bit - should try to fix
 				{
 					return SyntaxFactory.ElementAccessExpression(
 						(ExpressionSyntax)node.Expression.Accept(this),
 						SyntaxFactory.BracketedArgumentList(SyntaxFactory.SeparatedList(node.ArgumentList.Arguments.Select(a => (ArgumentSyntax)a.Accept(this)))));
 				}
+
 				return SyntaxFactory.InvocationExpression(
 					(ExpressionSyntax)node.Expression.Accept(this),
 					(ArgumentListSyntax)node.ArgumentList.Accept(this)

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -827,7 +827,17 @@ namespace RefactoringEssentials.CSharp.Converter
 					return SyntaxFactory.AliasQualifiedName((IdentifierNameSyntax) left, simpleNameSyntax);
 				}
 				else
-					return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, left, simpleNameSyntax);
+				{
+					var memberAccessExpressionSyntax = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, left, simpleNameSyntax);
+					if (semanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol methodSymbol && methodSymbol.ReturnType.Equals(semanticModel.GetTypeInfo(node).ConvertedType))
+					{
+						return SyntaxFactory.InvocationExpression(memberAccessExpressionSyntax, SyntaxFactory.ArgumentList());
+					}
+					else
+					{
+						return memberAccessExpressionSyntax;
+					}
+				}
 			}
 
 			public override CSharpSyntaxNode VisitConditionalAccessExpression(VBSyntax.ConditionalAccessExpressionSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -1196,7 +1196,7 @@ namespace RefactoringEssentials.CSharp.Converter
 
 			public override CSharpSyntaxNode VisitIdentifierName(VBSyntax.IdentifierNameSyntax node)
 			{
-				return SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, semanticModel, node.Parent is VBSyntax.AttributeSyntax));
+				return SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, semanticModel,  node.GetAncestor<VBSyntax.AttributeSyntax>() != null));
 			}
 
 			public override CSharpSyntaxNode VisitQualifiedName(VBSyntax.QualifiedNameSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
+++ b/RefactoringEssentials/CSharp/Converter/NodesVisitor.cs
@@ -911,7 +911,11 @@ namespace RefactoringEssentials.CSharp.Converter
 			{
 				if (node.Initializers.Count == 0 && node.Parent is VBSyntax.ArrayCreationExpressionSyntax)
 					return null;
-				return SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression, SyntaxFactory.SeparatedList(node.Initializers.Select(i => (ExpressionSyntax)i.Accept(this))));
+				var initializer = SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression, SyntaxFactory.SeparatedList(node.Initializers.Select(i => (ExpressionSyntax)i.Accept(this))));
+				var typeInfo = semanticModel.GetTypeInfo(node);
+				return typeInfo.Type == null && (typeInfo.ConvertedType?.SpecialType == SpecialType.System_Collections_IEnumerable || typeInfo.ConvertedType?.IsKind(SymbolKind.ArrayType) == true)
+					? (CSharpSyntaxNode) SyntaxFactory.ImplicitArrayCreationExpression(initializer)
+					: initializer;
 			}
 
 			public override CSharpSyntaxNode VisitObjectCollectionInitializer(VBSyntax.ObjectCollectionInitializerSyntax node)

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -119,7 +119,7 @@ namespace RefactoringEssentials.CSharp.Converter
 
 		static SyntaxTokenList ConvertModifiers(SyntaxTokenList modifiers, TokenContext context = TokenContext.Global)
 		{
-			return SyntaxFactory.TokenList(ConvertModifiersCore(modifiers, context));
+			return SyntaxFactory.TokenList(ConvertModifiersCore(modifiers, context).Where(t => t.Kind() != SyntaxKind.None));
 		}
 
 		static SyntaxToken? ConvertModifier(SyntaxToken m, TokenContext context = TokenContext.Global)

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -326,6 +326,7 @@ namespace RefactoringEssentials.CSharp.Converter
 				// assignment
 				case VBasic.SyntaxKind.SimpleAssignmentStatement:
 					return SyntaxKind.SimpleAssignmentExpression;
+				case VBasic.SyntaxKind.ConcatenateAssignmentStatement:
 				case VBasic.SyntaxKind.AddAssignmentStatement:
 					return SyntaxKind.AddAssignmentExpression;
 				case VBasic.SyntaxKind.SubtractAssignmentStatement:

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -200,7 +200,8 @@ namespace RefactoringEssentials.CSharp.Converter
 
 		static SyntaxToken ConvertToken(SyntaxToken t, TokenContext context = TokenContext.Global)
 		{
-			return SyntaxFactory.Token(ConvertToken(VBasic.VisualBasicExtensions.Kind(t), context));
+			VBasic.SyntaxKind vbSyntaxKind = VBasic.VisualBasicExtensions.Kind(t);
+			return SyntaxFactory.Token(ConvertToken(vbSyntaxKind, context));
 		}
 
 		static SyntaxKind ConvertToken(VBasic.SyntaxKind t, TokenContext context = TokenContext.Global)

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -159,7 +159,7 @@ namespace RefactoringEssentials.CSharp.Converter
 				if (!visibility)
 					yield return VisualBasicDefaultVisibility(context);
 			}
-			foreach (var token in modifiers.Where(m => !IgnoreInContext(m, context)))
+			foreach (var token in modifiers.Where(m => !IgnoreInContext(m, context)).OrderBy(m => m.IsKind(VBasic.SyntaxKind.PartialKeyword)))
 			{
 				var m = ConvertModifier(token, context);
 				if (m.HasValue) yield return m.Value;

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -191,9 +191,6 @@ namespace RefactoringEssentials.CSharp.Converter
 				|| (context == TokenContext.VariableOrConst && token.IsKind(VBasic.SyntaxKind.ConstKeyword));
 		}
 
-		/// <remarks>
-		/// Incorrectly returns private for structs instead of public
-		/// </remarks>
 		static SyntaxToken VisualBasicDefaultVisibility(TokenContext context)
 		{
 			switch (context)

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -285,6 +285,10 @@ namespace RefactoringEssentials.CSharp.Converter
 					return SyntaxKind.ReadOnlyKeyword;
 				case VBasic.SyntaxKind.OverridesKeyword:
 					return SyntaxKind.OverrideKeyword;
+				case VBasic.SyntaxKind.OverloadsKeyword:
+					return SyntaxKind.NewKeyword;
+				case VBasic.SyntaxKind.OverridableKeyword:
+					return SyntaxKind.VirtualKeyword;
 				case VBasic.SyntaxKind.SharedKeyword:
 					return SyntaxKind.StaticKeyword;
 				case VBasic.SyntaxKind.ConstKeyword:

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -95,7 +95,7 @@ namespace RefactoringEssentials.CSharp.Converter
 		{
 			string text = id.ValueText;
 			var keywordKind = SyntaxFacts.GetKeywordKind(text);
-			if (keywordKind != SyntaxKind.None && !SyntaxFacts.IsPredefinedType(keywordKind))
+			if (keywordKind != SyntaxKind.None)
 				return SyntaxFactory.Identifier("@" + text);
 			if (id.SyntaxTree == semanticModel.SyntaxTree)
 			{

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -93,10 +93,10 @@ namespace RefactoringEssentials.CSharp.Converter
 
 		static SyntaxToken ConvertIdentifier(SyntaxToken id, SemanticModel semanticModel, bool isAttribute = false)
 		{
-			var keywordKind = SyntaxFacts.GetKeywordKind(id.ValueText);
-			if (keywordKind != SyntaxKind.None && !SyntaxFacts.IsPredefinedType(keywordKind))
-				return SyntaxFactory.Identifier("@" + id.ValueText);
 			string text = id.ValueText;
+			var keywordKind = SyntaxFacts.GetKeywordKind(text);
+			if (keywordKind != SyntaxKind.None && !SyntaxFacts.IsPredefinedType(keywordKind))
+				return SyntaxFactory.Identifier("@" + text);
 			if (id.SyntaxTree == semanticModel.SyntaxTree)
 			{
 				var symbol = semanticModel.GetSymbolInfo(id.Parent).Symbol;
@@ -107,6 +107,11 @@ namespace RefactoringEssentials.CSharp.Converter
                         text = symbol.ContainingType.Name;
                         if (text.EndsWith("Attribute", StringComparison.Ordinal))
                             text = text.Remove(text.Length - "Attribute".Length);
+					}
+					else if (text.StartsWith("_", StringComparison.Ordinal) && symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Property) == true)
+					{
+
+						text = fieldSymbol.AssociatedSymbol.Name;
                     }
                     else
                         text = symbol.Name;

--- a/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
+++ b/RefactoringEssentials/CSharp/Converter/VisualBasicConverter.cs
@@ -124,7 +124,13 @@ namespace RefactoringEssentials.CSharp.Converter
 
 		static SyntaxToken? ConvertModifier(SyntaxToken m, TokenContext context = TokenContext.Global)
 		{
-			var token = ConvertToken(VBasic.VisualBasicExtensions.Kind(m), context);
+			VBasic.SyntaxKind vbSyntaxKind = VBasic.VisualBasicExtensions.Kind(m);
+			switch (vbSyntaxKind)
+			{
+				case VBasic.SyntaxKind.DateKeyword:
+					return SyntaxFactory.Identifier("System.DateTime");
+			}
+			var token = ConvertToken(vbSyntaxKind, context);
 			return token == SyntaxKind.None ? null : new SyntaxToken?(SyntaxFactory.Token(token));
 		}
 

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -28,6 +28,22 @@ World!"";
         }
 
         [Fact]
+        public void DateKeyword()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private DefaultDate as Date = Nothing
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private System.DateTime DefaultDate = default(Date);
+}");
+        }
+
+        [Fact]
         public void ConditionalExpression()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -44,6 +44,29 @@ class TestClass
         }
 
         [Fact]
+        public void StringConcatenationAssignment()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Dim str = ""Hello, ""
+        str &= ""World""
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        var str = ""Hello, "";
+        str += ""World"";
+    }
+}");
+        }
+
+        [Fact]
         public void ConditionalExpression()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -64,6 +64,26 @@ class TestClass
 }");
         }
 
+        [Fact]
+        public void EmptyArgumentLists()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Dim str = (New ThreadStaticAttribute).ToString
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        var str = (new ThreadStaticAttribute()).ToString();
+    }
+}");
+        }
 
         [Fact]
         public void StringConcatenationAssignment()

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -88,6 +88,29 @@ class TestClass
         }
 
         [Fact]
+        public void UsesSquareBracketsForIndexerButParenthesesForMethodInvocation()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Function TestMethod() As String()
+        Dim s = ""1,2""
+        Return s.Split(s(1))
+	End Function
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private string[] TestMethod()
+    {
+        var s = ""1,2"";
+        return s.Split(s[1]);
+    }
+}");
+        }
+
+        [Fact]
         public void ConditionalExpression()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -67,6 +67,27 @@ class TestClass
         }
 
         [Fact]
+        public void GetTypeExpression()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Dim typ = GetType(String)
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        var typ = typeof(string);
+    }
+}");
+        }
+
+        [Fact]
         public void ConditionalExpression()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/ExpressionTests.cs
+++ b/Tests/CSharp/Converter/ExpressionTests.cs
@@ -44,6 +44,28 @@ class TestClass
         }
 
         [Fact]
+        public void FullyTypeInferredEnumerableCreation()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Dim strings = { ""1"", ""2"" }
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        var strings = new[] { ""1"", ""2"" };
+    }
+}");
+        }
+
+
+        [Fact]
         public void StringConcatenationAssignment()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -348,6 +348,25 @@ class TestClass
 }");
         }
 
+        [Fact]
+        public void ParamArray()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub SomeBools(ParamArray anyName As Boolean())
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void SomeBools(params bool[] anyName)
+    {
+    }
+}");
+        }
+
 		[Fact(Skip = "Not implemented!")]
 		public void TestIndexer()
         {

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -370,6 +370,78 @@ class TestClass
         }
 
         [Fact]
+        public void PartialFriendClassWithOverloads()
+        {
+            TestConversionVisualBasicToCSharp(@"
+Partial Friend MustInherit Class TestClass1
+    Public Shared Sub CreateStatic()
+    End Sub
+
+    Public Sub CreateInstance()
+    End Sub
+
+    Public MustOverride Sub CreateAbstractInstance()
+
+    Public Overridable Sub CreateVirtualInstance()
+    End Sub
+End Class
+
+Friend Class TestClass2
+    Inherits TestClass1
+    Public Overloads Shared Sub CreateStatic()
+    End Sub
+
+    Public Overloads Sub CreateInstance()
+    End Sub
+
+    Public Overrides Sub CreateAbstractInstance()
+    End Sub
+
+    Public Overrides Sub CreateVirtualInstance()
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+internal abstract partial class TestClass1
+{
+    public static void CreateStatic()
+    {
+    }
+
+    public void CreateInstance()
+    {
+    }
+
+    public abstract void CreateAbstractInstance();
+
+    public virtual void CreateVirtualInstance()
+    {
+    }
+}
+
+internal class TestClass2 : TestClass1
+{
+    public new static void CreateStatic()
+    {
+    }
+
+    public new void CreateInstance()
+    {
+    }
+
+    public override void CreateAbstractInstance()
+    {
+    }
+
+    public override void CreateVirtualInstance()
+    {
+    }
+}");
+        }
+
+        [Fact]
         public void ClassWithGloballyQualifiedAttribute()
         {
             TestConversionVisualBasicToCSharp(@"<Global.System.Diagnostics.DebuggerDisplay(""Hello World"")>

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -21,7 +21,7 @@ class TestClass
 {
     const int answer = 42;
     private int value = 10;
-    readonly int v = 15;
+    private readonly int v = 15;
 }");
         }
 

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -348,6 +348,27 @@ class TestClass
 }");
         }
 
+
+        [Fact]
+        public void SynthesizedBackingFieldAccess()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Shared Property First As Integer
+
+    Private Second As Integer = _First
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private static int First { get; set; }
+
+    private int Second = First;
+}");
+        }
+
         [Fact]
         public void ClassWithGloballyQualifiedAttribute()
         {

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -386,6 +386,24 @@ class TestClass
         }
 
         [Fact]
+        public void FieldWithAttribute()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    <ThreadStatic>
+    Private Shared First As Integer
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    [ThreadStatic]
+    private static int First;
+}");
+        }
+
+        [Fact]
         public void ParamArray()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -369,6 +369,25 @@ class TestClass
 }");
         }
 
+
+        [Fact]
+        public void PropertyInitializers()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private ReadOnly Property First As New List(Of String)
+    Private Property Second As Integer = 0
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private List<string> First { get; } = new List<string>();
+    private int Second { get; set; } = 0;
+}");
+        }
+
         [Fact]
         public void PartialFriendClassWithOverloads()
         {

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -404,6 +404,25 @@ class TestClass
 }");
         }
 
+        [Fact]
+        public void ParamNamedBool()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub SomeBools(ParamArray bool As Boolean())
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void SomeBools(params bool[] @bool)
+    {
+    }
+}");
+        }
+
 		[Fact(Skip = "Not implemented!")]
 		public void TestIndexer()
         {

--- a/Tests/CSharp/Converter/MemberTests.cs
+++ b/Tests/CSharp/Converter/MemberTests.cs
@@ -349,6 +349,22 @@ class TestClass
         }
 
         [Fact]
+        public void ClassWithGloballyQualifiedAttribute()
+        {
+            TestConversionVisualBasicToCSharp(@"<Global.System.Diagnostics.DebuggerDisplay(""Hello World"")>
+Class TestClass
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+[global::System.Diagnostics.DebuggerDisplay(""Hello World"")]
+class TestClass
+{
+}");
+        }
+
+        [Fact]
         public void ParamArray()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/NamespaceLevelTests.cs
+++ b/Tests/CSharp/Converter/NamespaceLevelTests.cs
@@ -148,7 +148,7 @@ using Microsoft.VisualBasic;
 
 interface ITest : System.IDisposable
 {
-    private void Test();
+    void Test();
 }");
         }
 

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -216,6 +216,34 @@ class TestClass
         }
 
         [Fact]
+        public void WithBlock()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        With New StringBuilder
+            .Capacity = 20
+            .Length = 0
+        End With
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        {
+            var withBlock = new StringBuilder();
+            withBlock.Capacity = 20;
+            withBlock.Length = 0;
+        }
+    }
+}");
+        }
+
+        [Fact]
         public void ArrayInitializationStatement()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -241,7 +241,7 @@ class TestClass
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private Sub TestMethod()
-        With New StringBuilder
+        With New System.Text.StringBuilder
             .Capacity = 20
             .Length = 0
         End With
@@ -256,7 +256,7 @@ class TestClass
     private void TestMethod()
     {
         {
-            var withBlock = new StringBuilder();
+            var withBlock = new System.Text.StringBuilder();
             withBlock.Capacity = 20;
             withBlock.Length = 0;
         }

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -404,7 +404,7 @@ class TestClass
 }");
         }
 
-		[Fact(Skip = "Not implemented!")]
+		[Fact]
 		public void JaggedArrayInitializationStatement()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -853,7 +853,7 @@ class TestClass
 }");
         }
 
-        [Fact(Skip = "Not implemented!")]
+        [Fact]
         public void AddRemoveHandler()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
@@ -894,7 +894,6 @@ class TestClass
 
     private void MyHandler(object sender, EventArgs e)
     {
-
     }
 }");
         }

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -265,6 +265,44 @@ class TestClass
         }
 
         [Fact]
+        public void NestedWithBlock()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        With New System.Text.StringBuilder
+            Dim withBlock as Integer = 3
+            With New System.Text.StringBuilder
+                Dim withBlock1 as Integer = 4
+                .Capacity = withBlock1
+            End With
+
+            .Length = withBlock
+        End With
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        {
+            var withBlock2 = new System.Text.StringBuilder();
+            int withBlock = 3;
+            {
+                var withBlock3 = new System.Text.StringBuilder();
+                int withBlock1 = 4;
+                withBlock3.Capacity = withBlock1;
+            }
+
+            withBlock2.Length = withBlock;
+        }
+    }
+}");
+        }
+        [Fact]
         public void ArrayInitializationStatement()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -216,6 +216,27 @@ class TestClass
         }
 
         [Fact]
+        public void StopStatement()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Stop
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        System.Diagnostics.Debugger.Break();
+    }
+}");
+        }
+
+        [Fact]
         public void WithBlock()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -718,7 +718,7 @@ class TestClass
     private void TestMethod()
     {
         int[] b, s;
-        for (i = 0; i <= end; i++)
+        for (var i = 0; i <= end; i++)
             b[i] = s[i];
     }
 }");
@@ -744,7 +744,7 @@ class TestClass
     private void TestMethod()
     {
         int[] b, s;
-        for (i = 0; i <= end - 1; i++)
+        for (var i = 0; i <= end - 1; i++)
             b[i] = s[i];
     }
 }");

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -210,7 +210,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        System.Environment.Exit(-1);
+        System.Environment.Exit(0);
     }
 }");
         }

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -195,6 +195,27 @@ class TestClass
         }
 
         [Fact]
+        public void EndStatement()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        End
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        System.Environment.Exit(-1);
+    }
+}");
+        }
+
+        [Fact]
         public void ArrayInitializationStatement()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -960,14 +960,22 @@ class TestClass
             case 0:
             case 1:
             case 2:
-                Console.Write(""number is 0, 1, 2"");
-                break;
+                {
+                    Console.Write(""number is 0, 1, 2"");
+                    break;
+                }
+
             case 5:
-                Console.Write(""section 5"");
-                break;
+                {
+                    Console.Write(""section 5"");
+                    break;
+                }
+
             default:
-                Console.Write(""default section"");
-                break;
+                {
+                    Console.Write(""default section"");
+                    break;
+                }
         }
     }
 }");

--- a/Tests/CSharp/Converter/StatementTests.cs
+++ b/Tests/CSharp/Converter/StatementTests.cs
@@ -231,12 +231,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        int[] b =
-        {
-            1,
-            2,
-            3
-        };
+        int[] b = new[] { 1, 2, 3 };
     }
 }");
         }
@@ -257,12 +252,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        var b =
-        {
-            1,
-            2,
-            3
-        };
+        var b = new[] { 1, 2, 3 };
     }
 }");
         }
@@ -304,12 +294,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        int[] b = new int[3]
-        {
-            1,
-            2, 
-            3
-        };
+        int[] b = new int[3] { 1, 2, 3 };
     }
 }");
         }
@@ -435,7 +420,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        int[][] b = { new int[] { 1, 2 }, new int[] { 3, 4 } };
+        int[][] b = new[] { new int[] { 1, 2 }, new int[] { 3, 4 } };
     }
 }");
         }

--- a/Tests/CSharp/Converter/TypeCastTests.cs
+++ b/Tests/CSharp/Converter/TypeCastTests.cs
@@ -24,7 +24,7 @@ class Class1
     private void Test()
     {
         object o = 5;
-        int i = (int)o;
+        int i = System.Convert.ToInt32(o);
     }
 }
 ");
@@ -50,7 +50,7 @@ class Class1
     private void Test()
     {
         object o = ""Test"";
-        string s = (string)o;
+        string s = System.Convert.ToString(o);
     }
 }
 ");

--- a/Tests/Common/DiagnosticTestBase.cs
+++ b/Tests/Common/DiagnosticTestBase.cs
@@ -20,6 +20,7 @@ namespace RefactoringEssentials.Tests
         static MetadataReference systemAssembly;
         static MetadataReference systemXmlLinq;
         static MetadataReference systemCore;
+       private static MetadataReference visualBasic;
 
         internal static MetadataReference[] DefaultMetadataReferences;
 
@@ -33,11 +34,13 @@ namespace RefactoringEssentials.Tests
                 systemAssembly = MetadataReference.CreateFromFile(typeof(System.ComponentModel.BrowsableAttribute).Assembly.Location);
                 systemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XElement).Assembly.Location);
                 systemCore = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+                visualBasic = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Constants).Assembly.Location);
                 DefaultMetadataReferences = new[] {
                     mscorlib,
                     systemAssembly,
                     systemCore,
-                    systemXmlLinq
+                    systemXmlLinq,
+                    visualBasic
                 };
 
                 foreach (var provider in typeof(DiagnosticAnalyzerCategories).Assembly.GetTypes().Where(t => t.GetCustomAttributes(typeof(ExportCodeFixProviderAttribute), false).Length > 0))

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -65,6 +65,7 @@
       <HintPath>..\packages\Microsoft.CodeAnalysis.Elfie.0.10.6\lib\net46\Microsoft.CodeAnalysis.Elfie.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>


### PR DESCRIPTION
I have a whole collection of VB to C# converter fixes that I did in the course of a conversion effort.
Obviously this isn't an "accepted up-for-grabs" issue, but since I was doing the work anyway seems sensible to try and contribute it back to the project. This seemed a sensible place to start the discussion so we can reference the changes directly.

Could you let me know the best way to get some/all of this merged. Twitter mentioned that @siegfriedpammer was the one to talk to?

So long as you're interested in merging the changes I'm happy to do stuff like:
* [x] Create a few targeted test cases (I was testing against a real project before).
* Slice things up to fit into chunks that make sense for you to review
